### PR TITLE
fix(content): preserve session comment drafts

### DIFF
--- a/src/content/reader/ui/ReaderDialogPanel.ts
+++ b/src/content/reader/ui/ReaderDialogPanel.ts
@@ -11,6 +11,7 @@ import { renderStitchRuntimeSurface } from '@content/stitch/runtimeSurfaceRender
 import { panelStyleSheetManager } from '@content/shared/panels/styleSheetManager';
 import { bindSessionPanelResize } from '@content/shared/panels/sessionPanelResize';
 import { bindSessionItemPreviewExpansion } from '@content/shared/panels/sessionItemPreviewExpansion';
+import { SessionCommentDraftController } from '@content/shared/panels/sessionCommentDrafts';
 import { patchExportDestinationRow } from '@content/shared/exportDestinationDom';
 import type { ExportDestinationSurfacePreview } from '@options/stitch/types';
 import { focusContentDialogElementByDataset } from '@ui/hosts/content/contentDialogFocus';
@@ -21,20 +22,17 @@ interface ReaderDialogPanelOptions {
   resolveAssetUrl?: (path: string) => string;
 }
 
-export class ReaderDialogPanel
-  implements
-    UiMountable<
-      HTMLElement | undefined,
-      | {
-          texts?: ReaderPanelTexts;
-          count?: number;
-          hint?: string;
-          highlights?: ReaderPanelHighlight[];
-        }
-      | undefined,
-      HTMLElement
-    >
-{
+export class ReaderDialogPanel implements UiMountable<
+  HTMLElement | undefined,
+  | {
+      texts?: ReaderPanelTexts;
+      count?: number;
+      hint?: string;
+      highlights?: ReaderPanelHighlight[];
+    }
+  | undefined,
+  HTMLElement
+> {
   readonly popupLifecycle = { preserveOnTransientClose: true };
 
   private renderRoot: HTMLElement;
@@ -47,6 +45,13 @@ export class ReaderDialogPanel
   private destination: ExportDestinationSurfacePreview | undefined;
   private highlightCount = 0;
   private editingHighlightId: string | null = null;
+  private readonly commentDrafts = new SessionCommentDraftController<ReaderPanelHighlight>({
+    datasetKey: 'highlightInput',
+    inputSelector: '[data-highlight-input]',
+    getItems: () => this.highlights,
+    getRoot: () => this.renderRoot.shadowRoot,
+    submitDraft: (id, draft) => this.options.callbacks.onSubmitHighlightEdit(id, draft)
+  });
   private pendingNoteFocusHighlightId: string | null = null;
   private collapsed = false;
 
@@ -108,19 +113,8 @@ export class ReaderDialogPanel
       this.texts = { ...this.texts, hint: payload.hint };
     }
     if (payload.highlights) {
-      const previousCount = this.highlights.length;
-      if (this.collapsed && payload.highlights.length > this.highlights.length) {
-        this.collapsed = false;
-      }
-      this.highlights = [...payload.highlights];
-      this.highlightCount = payload.highlights.length;
-      const newestHighlight =
-        payload.highlights.length > previousCount ? payload.highlights.at(-1) : undefined;
-      if (newestHighlight?.id) {
-        this.editingHighlightId = newestHighlight.id;
-        this.pendingNoteFocusHighlightId = newestHighlight.id;
-      }
-      this.rerender();
+      const newestHighlight = this.applyHighlights(payload.highlights);
+      this.rerender({ captureDrafts: false });
       this.focusHighlightNoteInput(newestHighlight?.id);
       return this.renderRoot;
     }
@@ -152,24 +146,15 @@ export class ReaderDialogPanel
   }
 
   setHighlights(highlights: ReaderPanelHighlight[]): void {
-    const previousCount = this.highlights.length;
-    if (this.collapsed && highlights.length > this.highlights.length) {
-      this.collapsed = false;
-    }
-    this.highlights = [...highlights];
-    this.highlightCount = highlights.length;
-    const newestHighlight = highlights.length > previousCount ? highlights.at(-1) : undefined;
-    if (newestHighlight?.id) {
-      this.editingHighlightId = newestHighlight.id;
-      this.pendingNoteFocusHighlightId = newestHighlight.id;
-    }
+    const newestHighlight = this.applyHighlights(highlights);
     this.rerender();
     this.focusHighlightNoteInput(newestHighlight?.id);
   }
 
   stopEditing(): void {
+    this.commentDrafts.clear(this.editingHighlightId);
     this.editingHighlightId = null;
-    this.rerender();
+    this.rerender({ captureDrafts: false });
   }
 
   isEditing(): boolean {
@@ -190,10 +175,13 @@ export class ReaderDialogPanel
     this.renderRoot.remove();
   }
 
-  private rerender(): void {
+  private rerender(options: { captureDrafts?: boolean } = {}): void {
     const shadow = this.renderRoot.shadowRoot;
     if (!shadow) {
       return;
+    }
+    if (options.captureDrafts !== false) {
+      this.commentDrafts.captureRenderedInputs();
     }
     this.resizeDisposer?.();
     this.resizeDisposer = null;
@@ -210,10 +198,7 @@ export class ReaderDialogPanel
   private renderSurface(): HTMLElement {
     const content = createReaderSurfaceContent({
       texts: this.texts,
-      highlights: this.highlights.map((highlight) => ({
-        ...highlight,
-        comment: this.editingHighlightId === highlight.id ? highlight.comment : highlight.comment
-      })),
+      highlights: this.highlights.map((highlight) => this.commentDrafts.withDraft(highlight)),
       counter: this.formatCounter(this.highlightCount),
       iconUrl: this.resolveAssetUrl('icons/60x60/allinob_icon_readingt.png'),
       ...(this.destination ? { destination: this.destination } : {}),
@@ -229,9 +214,8 @@ export class ReaderDialogPanel
       surfaceId: 'reader',
       appData: content,
       actions: {
-        'reader:finish': () => {
-          void this.options.callbacks.onFinish();
-        },
+        'reader:finish': () =>
+          this.commentDrafts.runAfterFlush(() => this.options.callbacks.onFinish()),
         'reader:cancel': () => this.options.callbacks.onCancel(),
         'export-destination:select': (event) => {
           const id = this.resolveActionId(event, 'destinationId');
@@ -247,6 +231,7 @@ export class ReaderDialogPanel
         'reader:delete': (event) => {
           const id = this.resolveActionId(event, 'highlightId');
           if (id) {
+            this.commentDrafts.clear(id);
             this.options.callbacks.onDeleteHighlight(id);
           }
         },
@@ -256,7 +241,7 @@ export class ReaderDialogPanel
             ? surface.querySelector<HTMLInputElement>(`[data-highlight-input="${CSS.escape(id)}"]`)
             : null;
           if (id && input) {
-            void this.options.callbacks.onSubmitHighlightEdit(id, input.value);
+            void this.commentDrafts.submit(id, input.value);
           }
         }
       }
@@ -315,13 +300,6 @@ export class ReaderDialogPanel
     });
   }
 
-  private currentSurface(): HTMLElement | null {
-    return (
-      this.renderRoot.shadowRoot?.querySelector<HTMLElement>('[data-stitch-surface="reader"]') ??
-      null
-    );
-  }
-
   private resolveActionId(
     event: Event,
     datasetKey: 'highlightId' | 'destinationId'
@@ -354,14 +332,25 @@ export class ReaderDialogPanel
       input?.addEventListener('focus', () => {
         this.editingHighlightId = id;
       });
-      input?.addEventListener('keydown', (event) => {
-        if (event.key !== 'Enter') {
-          return;
-        }
-        event.preventDefault();
-        void this.options.callbacks.onSubmitHighlightEdit(id, input.value);
-      });
+      this.commentDrafts.bindInput(input, id);
     });
+  }
+
+  private applyHighlights(highlights: ReaderPanelHighlight[]): ReaderPanelHighlight | undefined {
+    this.commentDrafts.captureRenderedInputs();
+    const previousCount = this.highlights.length;
+    if (this.collapsed && highlights.length > previousCount) {
+      this.collapsed = false;
+    }
+    this.highlights = [...highlights];
+    this.highlightCount = highlights.length;
+    this.commentDrafts.reconcile(this.highlights);
+    const newestHighlight = highlights.length > previousCount ? highlights.at(-1) : undefined;
+    if (newestHighlight?.id) {
+      this.editingHighlightId = newestHighlight.id;
+      this.pendingNoteFocusHighlightId = newestHighlight.id;
+    }
+    return newestHighlight;
   }
 
   private focusHighlightNoteInput(highlightId: string | null | undefined): void {

--- a/src/content/shared/panels/sessionCommentDrafts.ts
+++ b/src/content/shared/panels/sessionCommentDrafts.ts
@@ -1,0 +1,130 @@
+export interface SessionCommentDraftItem {
+  id: string;
+  comment: string;
+}
+
+export type SessionCommentDraftedItem<T extends SessionCommentDraftItem> = T & {
+  draft?: string;
+};
+
+interface SessionCommentDraftControllerOptions<T extends SessionCommentDraftItem> {
+  datasetKey: string;
+  inputSelector: string;
+  getItems: () => T[];
+  getRoot: () => ParentNode | null;
+  submitDraft: (id: string, draft: string) => void | Promise<void>;
+}
+
+export class SessionCommentDraftStore {
+  private readonly drafts = new Map<string, string>();
+
+  get(id: string): string | undefined {
+    return this.drafts.get(id);
+  }
+
+  hasDrafts(): boolean {
+    return this.drafts.size > 0;
+  }
+
+  set(id: string, draft: string, canonicalComment: string): void {
+    if (draft === canonicalComment) {
+      this.drafts.delete(id);
+      return;
+    }
+    this.drafts.set(id, draft);
+  }
+
+  clear(id: string | null | undefined): void {
+    if (!id) {
+      return;
+    }
+    this.drafts.delete(id);
+  }
+
+  reconcile(items: SessionCommentDraftItem[]): void {
+    const commentsById = new Map(items.map((item) => [item.id, item.comment]));
+    for (const [id, draft] of this.drafts) {
+      const comment = commentsById.get(id);
+      if (comment === undefined || draft === comment) {
+        this.drafts.delete(id);
+      }
+    }
+  }
+}
+
+export class SessionCommentDraftController<T extends SessionCommentDraftItem> {
+  private readonly store = new SessionCommentDraftStore();
+
+  constructor(private readonly options: SessionCommentDraftControllerOptions<T>) {}
+
+  remember(id: string, value: string): void {
+    this.store.set(id, value, this.findCanonicalComment(id));
+  }
+
+  clear(id: string | null | undefined): void {
+    this.store.clear(id);
+  }
+
+  reconcile(items: T[]): void {
+    this.store.reconcile(items);
+  }
+
+  withDraft(item: T): SessionCommentDraftedItem<T> {
+    const draft = this.store.get(item.id);
+    return draft === undefined ? item : { ...item, draft };
+  }
+
+  bindInput(input: HTMLInputElement | null | undefined, id: string): void {
+    input?.addEventListener('input', () => this.remember(id, input.value));
+    input?.addEventListener('keydown', (event) => {
+      if (!(event instanceof KeyboardEvent) || event.key !== 'Enter') {
+        return;
+      }
+      event.preventDefault();
+      void this.submit(id, input.value);
+    });
+  }
+
+  captureRenderedInputs(): void {
+    this.options
+      .getRoot()
+      ?.querySelectorAll<HTMLInputElement>(this.options.inputSelector)
+      .forEach((input) => {
+        const id = input.dataset[this.options.datasetKey];
+        if (id) {
+          this.remember(id, input.value);
+        }
+      });
+  }
+
+  async submit(id: string, value: string): Promise<void> {
+    this.remember(id, value);
+    await this.options.submitDraft(id, value);
+    this.store.clear(id);
+  }
+
+  runAfterFlush(action: () => void | Promise<void>): void {
+    this.captureRenderedInputs();
+    if (!this.store.hasDrafts()) {
+      void action();
+      return;
+    }
+    void this.flush().then(action);
+  }
+
+  private async flush(): Promise<void> {
+    this.captureRenderedInputs();
+    for (const item of this.options.getItems()) {
+      const draft = this.store.get(item.id);
+      if (draft === undefined) {
+        continue;
+      }
+      await this.options.submitDraft(item.id, draft);
+      this.store.clear(item.id);
+    }
+  }
+
+  private findCanonicalComment(id: string): string {
+    return this.options.getItems().find((item) => item.id === id)?.comment ?? '';
+  }
+}

--- a/src/content/stitch/runtimeSurfaceContent.ts
+++ b/src/content/stitch/runtimeSurfaceContent.ts
@@ -19,11 +19,7 @@ const CLIPPER_ICON_PATH = 'icons/60x60/allinob_icon_clipt.png';
 const READER_ICON_PATH = 'icons/60x60/allinob_icon_readingt.png';
 
 function hero(title: string): PreviewContent['overview']['hero'] {
-  return {
-    title,
-    description: '',
-    pills: []
-  };
+  return { title, description: '', pills: [] };
 }
 
 function createRuntimeContent(): PreviewContent {
@@ -258,7 +254,7 @@ export function createClipperSurfaceContent(input: {
 
 export function createReaderSurfaceContent(input: {
   texts: ReaderPanelTexts;
-  highlights: ReaderPanelHighlight[];
+  highlights: Array<ReaderPanelHighlight & { draft?: string }>;
   counter: string;
   actions: SurfaceAction[];
   destination?: ExportDestinationSurfacePreview;
@@ -294,6 +290,7 @@ export function createReaderSurfaceContent(input: {
           fullText: highlight.fullText,
           commentPreview: highlight.commentPreview || input.texts.highlightNoComment,
           comment: highlight.comment || '',
+          ...(highlight.draft !== undefined ? { draft: highlight.draft } : {}),
           timestamp: String(highlight.timestamp)
         }))
       }
@@ -303,7 +300,7 @@ export function createReaderSurfaceContent(input: {
 
 export function createVideoSurfaceContent(input: {
   texts: VideoPanelTexts;
-  captures: VideoPanelCapture[];
+  captures: Array<VideoPanelCapture & { draft?: string }>;
   counter: string;
   actions: SurfaceAction[];
   destination?: ExportDestinationSurfacePreview;
@@ -345,6 +342,7 @@ export function createVideoSurfaceContent(input: {
           fullText: capture.selectionPreview || '',
           commentPreview: capture.commentPreview ?? capture.comment ?? '',
           comment: capture.comment ?? '',
+          ...(capture.draft !== undefined ? { draft: capture.draft } : {}),
           hasScreenshot: capture.hasScreenshot ?? false,
           meta: capture.shareUrl || capture.fragmentUrl || ''
         }))

--- a/src/content/video/ui/VideoDialogPanel.ts
+++ b/src/content/video/ui/VideoDialogPanel.ts
@@ -11,6 +11,7 @@ import { renderStitchRuntimeSurface } from '@content/stitch/runtimeSurfaceRender
 import { panelStyleSheetManager } from '@content/shared/panels/styleSheetManager';
 import { bindSessionPanelResize } from '@content/shared/panels/sessionPanelResize';
 import { bindSessionItemPreviewExpansion } from '@content/shared/panels/sessionItemPreviewExpansion';
+import { SessionCommentDraftController } from '@content/shared/panels/sessionCommentDrafts';
 import { patchExportDestinationRow } from '@content/shared/exportDestinationDom';
 import type { ExportDestinationSurfacePreview } from '@options/stitch/types';
 import { focusContentDialogElementByDataset } from '@ui/hosts/content/contentDialogFocus';
@@ -21,15 +22,12 @@ interface VideoDialogPanelOptions {
   initialCollapsed?: boolean;
 }
 
-export class VideoDialogPanel
-  implements
-    UiMountable<
-      HTMLElement | undefined,
-      | { texts?: VideoPanelTexts; count?: number; hint?: string; captures?: VideoPanelCapture[] }
-      | undefined,
-      HTMLElement
-    >
-{
+export class VideoDialogPanel implements UiMountable<
+  HTMLElement | undefined,
+  | { texts?: VideoPanelTexts; count?: number; hint?: string; captures?: VideoPanelCapture[] }
+  | undefined,
+  HTMLElement
+> {
   readonly popupLifecycle = { preserveOnTransientClose: true };
 
   private renderRoot: HTMLElement;
@@ -42,7 +40,13 @@ export class VideoDialogPanel
   private destination: ExportDestinationSurfacePreview | undefined;
   private captureCount = 0;
   private editingCaptureId: string | null = null;
-  private editingDraft = '';
+  private readonly commentDrafts = new SessionCommentDraftController<VideoPanelCapture>({
+    datasetKey: 'captureInput',
+    inputSelector: '[data-capture-input]',
+    getItems: () => this.captures,
+    getRoot: () => this.renderRoot.shadowRoot,
+    submitDraft: (id, draft) => this.options.callbacks.onSubmitCaptureEdit(id, draft)
+  });
   private collapsed = false;
   private keepCollapsedForNextCaptureUpdate = false;
 
@@ -105,16 +109,9 @@ export class VideoDialogPanel
       this.texts = { ...this.texts, hint: payload.hint };
     }
     if (payload.captures) {
-      if (
-        this.collapsed &&
-        payload.captures.length > this.captures.length &&
-        !this.keepCollapsedForNextCaptureUpdate
-      ) {
-        this.collapsed = false;
-      }
-      this.keepCollapsedForNextCaptureUpdate = false;
-      this.captures = [...payload.captures];
-      this.captureCount = payload.captures.length;
+      this.applyCaptures(payload.captures);
+      this.rerender({ captureDrafts: false });
+      return this.renderRoot;
     }
     this.rerender();
     return this.renderRoot;
@@ -144,32 +141,24 @@ export class VideoDialogPanel
   }
 
   setCaptures(captures: VideoPanelCapture[]): void {
-    if (
-      this.collapsed &&
-      captures.length > this.captures.length &&
-      !this.keepCollapsedForNextCaptureUpdate
-    ) {
-      this.collapsed = false;
-    }
-    this.keepCollapsedForNextCaptureUpdate = false;
-    this.captures = [...captures];
-    this.captureCount = captures.length;
-    this.rerender();
+    this.applyCaptures(captures);
+    this.rerender({ captureDrafts: false });
   }
 
   beginEditingCapture(id: string, draft: string): void {
+    this.commentDrafts.captureRenderedInputs();
     this.editingCaptureId = id;
-    this.editingDraft = draft;
-    this.rerender();
-    queueMicrotask(() => {
-      focusContentDialogElementByDataset(this.renderRoot.shadowRoot, 'captureInput', id);
-    });
+    this.commentDrafts.remember(id, draft);
+    this.rerender({ captureDrafts: false });
+    queueMicrotask(() =>
+      focusContentDialogElementByDataset(this.renderRoot.shadowRoot, 'captureInput', id)
+    );
   }
 
   stopEditing(): void {
+    this.commentDrafts.clear(this.editingCaptureId);
     this.editingCaptureId = null;
-    this.editingDraft = '';
-    this.rerender();
+    this.rerender({ captureDrafts: false });
   }
 
   collapse(): void {
@@ -188,10 +177,13 @@ export class VideoDialogPanel
     this.renderRoot.remove();
   }
 
-  private rerender(): void {
+  private rerender(options: { captureDrafts?: boolean } = {}): void {
     const shadow = this.renderRoot.shadowRoot;
     if (!shadow) {
       return;
+    }
+    if (options.captureDrafts !== false) {
+      this.commentDrafts.captureRenderedInputs();
     }
     this.resizeDisposer?.();
     this.resizeDisposer = null;
@@ -207,7 +199,7 @@ export class VideoDialogPanel
   private renderSurface(): HTMLElement {
     const content = createVideoSurfaceContent({
       texts: this.texts,
-      captures: this.captures,
+      captures: this.captures.map((capture) => this.commentDrafts.withDraft(capture)),
       counter: this.formatCounter(this.captureCount),
       ...(this.destination ? { destination: this.destination } : {}),
       actions: [
@@ -219,17 +211,18 @@ export class VideoDialogPanel
       content.surfaces.video.labels.subtitle = '';
     }
     content.surfaces.video.captures = content.surfaces.video.captures.map((capture) =>
-      capture.id === this.editingCaptureId
-        ? { ...capture, editing: true, draft: this.editingDraft }
-        : capture
+      capture.id === this.editingCaptureId ? { ...capture, editing: true } : capture
     );
     const surface = renderStitchRuntimeSurface({
       surfaceId: 'video',
       appData: content,
       actions: {
-        'video:add': () => this.options.callbacks.onAddCapture('button'),
-        'video:add-note': () => this.options.callbacks.onAddCapture('note-input'),
-        'video:finish': () => this.options.callbacks.onFinish(),
+        'video:add': () =>
+          this.commentDrafts.runAfterFlush(() => this.options.callbacks.onAddCapture('button')),
+        'video:add-note': () =>
+          this.commentDrafts.runAfterFlush(() => this.options.callbacks.onAddCapture('note-input')),
+        'video:finish': () =>
+          this.commentDrafts.runAfterFlush(() => this.options.callbacks.onFinish()),
         'video:cancel': () => this.options.callbacks.onCancel(),
         'export-destination:select': (event) => {
           const id = this.resolveActionId(event, 'destinationId');
@@ -245,6 +238,7 @@ export class VideoDialogPanel
         'video:delete': (event) => {
           const id = this.resolveActionId(event, 'captureId');
           if (id) {
+            this.commentDrafts.clear(id);
             this.options.callbacks.onDeleteCapture(id);
           }
         },
@@ -308,13 +302,6 @@ export class VideoDialogPanel
     });
   }
 
-  private currentSurface(): HTMLElement | null {
-    return (
-      this.renderRoot.shadowRoot?.querySelector<HTMLElement>('[data-stitch-surface="video"]') ??
-      null
-    );
-  }
-
   private resolveActionId(event: Event, datasetKey: 'captureId' | 'destinationId'): string | null {
     const target = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
     if (datasetKey === 'destinationId') {
@@ -341,14 +328,23 @@ export class VideoDialogPanel
         this.options.callbacks.onFocusCapture(id);
       });
       const input = item.querySelector<HTMLInputElement>('[data-capture-input]');
-      input?.addEventListener('keydown', (event) => {
-        if (!(event instanceof KeyboardEvent) || event.key !== 'Enter') {
-          return;
-        }
-        event.preventDefault();
-        void this.options.callbacks.onSubmitCaptureEdit(id, input.value);
-      });
+      this.commentDrafts.bindInput(input, id);
     });
+  }
+
+  private applyCaptures(captures: VideoPanelCapture[]): void {
+    this.commentDrafts.captureRenderedInputs();
+    if (
+      this.collapsed &&
+      captures.length > this.captures.length &&
+      !this.keepCollapsedForNextCaptureUpdate
+    ) {
+      this.collapsed = false;
+    }
+    this.keepCollapsedForNextCaptureUpdate = false;
+    this.captures = [...captures];
+    this.captureCount = captures.length;
+    this.commentDrafts.reconcile(this.captures);
   }
 
   private isInteractiveCaptureTarget(target: Element | null): boolean {

--- a/tests/unit/content/reader/ReaderDialogPanel.test.ts
+++ b/tests/unit/content/reader/ReaderDialogPanel.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReaderDialogPanel } from '../../../../src/content/reader/ui/ReaderDialogPanel';
 import type {
   ReaderPanelCallbacks,
+  ReaderPanelHighlight,
   ReaderPanelTexts
 } from '../../../../src/content/reader/application/readerPanelModel';
 
@@ -46,6 +47,19 @@ function createReaderPanelCallbacks(): ReaderPanelCallbacks {
     onDeleteHighlight: vi.fn(),
     onFocusHighlight: vi.fn(),
     onSubmitHighlightEdit: vi.fn()
+  };
+}
+
+function createHighlight(overrides: Partial<ReaderPanelHighlight> = {}): ReaderPanelHighlight {
+  return {
+    id: 'h-1',
+    index: 1,
+    excerpt: 'Selected text',
+    fullText: 'Selected text',
+    comment: '',
+    commentPreview: '',
+    timestamp: Date.now(),
+    ...overrides
   };
 }
 
@@ -126,10 +140,73 @@ describe('ReaderDialogPanel', () => {
     panel.destroy();
   });
 
-  it('focuses reader controls through the shared content dialog focus helper', async () => {
-    const { focusContentDialogElement } = await import(
-      '../../../../src/ui/hosts/content/contentDialogFocus'
+  it('preserves unsaved highlight note drafts when additional highlights render', () => {
+    const panel = new ReaderDialogPanel({
+      texts: createReaderPanelTexts(),
+      callbacks: createReaderPanelCallbacks()
+    });
+    panel.mount(document.body);
+    const first = createHighlight({ id: 'h-1', index: 1 });
+    const second = createHighlight({ id: 'h-2', index: 2 });
+    panel.setHighlights([first, second]);
+
+    const secondInput = panel.element.shadowRoot?.querySelector<HTMLInputElement>(
+      '[data-highlight-input="h-2"]'
     );
+    expect(secondInput).toBeTruthy();
+    if (!secondInput) {
+      throw new Error('second highlight input missing');
+    }
+    secondInput.value = 'second draft';
+    secondInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    panel.setHighlights([first, second, createHighlight({ id: 'h-3', index: 3 })]);
+
+    expect(
+      panel.element.shadowRoot?.querySelector<HTMLInputElement>('[data-highlight-input="h-2"]')
+        ?.value
+    ).toBe('second draft');
+    expect(panel.element.shadowRoot?.activeElement).toBe(
+      panel.element.shadowRoot?.querySelector('[data-highlight-input="h-3"]')
+    );
+
+    panel.destroy();
+  });
+
+  it('flushes unsaved highlight note drafts before finishing', async () => {
+    const callbacks = createReaderPanelCallbacks();
+    const panel = new ReaderDialogPanel({
+      texts: createReaderPanelTexts(),
+      callbacks
+    });
+    panel.mount(document.body);
+    panel.setHighlights([createHighlight({ id: 'h-1', index: 1 })]);
+
+    const input = panel.element.shadowRoot?.querySelector<HTMLInputElement>(
+      '[data-highlight-input="h-1"]'
+    );
+    expect(input).toBeTruthy();
+    if (!input) {
+      throw new Error('highlight input missing');
+    }
+    input.value = 'finish draft';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    panel.element.shadowRoot?.querySelector<HTMLButtonElement>('[data-role="export-btn"]')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(callbacks.onSubmitHighlightEdit).toHaveBeenCalledWith('h-1', 'finish draft');
+    expect(callbacks.onFinish).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(callbacks.onSubmitHighlightEdit).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(callbacks.onFinish).mock.invocationCallOrder[0] ?? 0
+    );
+
+    panel.destroy();
+  });
+
+  it('focuses reader controls through the shared content dialog focus helper', async () => {
+    const { focusContentDialogElement } =
+      await import('../../../../src/ui/hosts/content/contentDialogFocus');
     const panel = new ReaderDialogPanel({
       texts: createReaderPanelTexts(),
       callbacks: createReaderPanelCallbacks()

--- a/tests/unit/content/video/VideoDialogPanel.test.ts
+++ b/tests/unit/content/video/VideoDialogPanel.test.ts
@@ -202,6 +202,66 @@ describe('VideoDialogPanel', () => {
     panel.destroy();
   });
 
+  it('preserves unsaved capture note drafts when additional captures render', () => {
+    const panel = new VideoDialogPanel({ callbacks, texts });
+    const first = createCapture({ id: 'capture-1', index: 1, timeLabel: '00:42' });
+    const second = createCapture({ id: 'capture-2', index: 2, timeLabel: '01:10' });
+    panel.show();
+    panel.setCaptures([first, second]);
+    panel.beginEditingCapture(second.id, second.comment);
+
+    const secondInput = panel.element.shadowRoot?.querySelector<HTMLInputElement>(
+      '[data-capture-input="capture-2"]'
+    );
+    expect(secondInput).toBeTruthy();
+    if (!secondInput) {
+      throw new Error('second capture input missing');
+    }
+    secondInput.value = 'second capture draft';
+    secondInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    panel.setCaptures([
+      first,
+      second,
+      createCapture({ id: 'capture-3', index: 3, timeLabel: '02:20' })
+    ]);
+
+    expect(
+      panel.element.shadowRoot?.querySelector<HTMLInputElement>('[data-capture-input="capture-2"]')
+        ?.value
+    ).toBe('second capture draft');
+
+    panel.destroy();
+  });
+
+  it('flushes unsaved capture note drafts before finishing', async () => {
+    const panel = new VideoDialogPanel({ callbacks, texts });
+    panel.show();
+    panel.setCaptures([createCapture({ id: 'capture-1', index: 1 })]);
+    panel.beginEditingCapture('capture-1', '');
+
+    const input = panel.element.shadowRoot?.querySelector<HTMLInputElement>(
+      '[data-capture-input="capture-1"]'
+    );
+    expect(input).toBeTruthy();
+    if (!input) {
+      throw new Error('capture input missing');
+    }
+    input.value = 'finish capture draft';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    panel.element.shadowRoot?.querySelector<HTMLButtonElement>('[data-role="finish-btn"]')?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(callbacks.onSubmitCaptureEdit).toHaveBeenCalledWith('capture-1', 'finish capture draft');
+    expect(callbacks.onFinish).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(callbacks.onSubmitCaptureEdit).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(callbacks.onFinish).mock.invocationCallOrder[0] ?? 0
+    );
+
+    panel.destroy();
+  });
+
   it('keeps cancel and capture editor focus behavior stable', async () => {
     const panel = new VideoDialogPanel({ callbacks, texts });
     const capture = createCapture({ comment: 'draft', commentPreview: 'draft' });


### PR DESCRIPTION
## Summary
- Preserve unsaved Reader and Video session comment drafts across list re-renders.
- Flush pending comment drafts before finish/add actions so exports do not drop typed notes.
- Add regression coverage for multiple comment additions and finish-time flush behavior.

## Verification
- npm run test:unit
- npm run typecheck:app
- npm run typecheck:tests
- npm run quality
- npm run build:fast
- npm run verify:stitch-secondary
- Post-amend targeted: npm run test:unit -- tests/unit/tools/reportPerformanceHotspots.test.ts tests/unit/content/reader/ReaderDialogPanel.test.ts tests/unit/content/video/VideoDialogPanel.test.ts
