### PR TITLE
Fix session panel layout persistence

### DIFF
--- a/src/content/reader/ui/ReaderDialogPanel.ts
+++ b/src/content/reader/ui/ReaderDialogPanel.ts
@@ -340,7 +340,8 @@ export class ReaderDialogPanel
   private applyHighlights(highlights: ReaderPanelHighlight[]): ReaderPanelHighlight | undefined {
     this.commentDrafts.captureRenderedInputs();
     const previousCount = this.highlights.length;
-    if (this.collapsePersistence.value && highlights.length > previousCount) {
+    const shouldExpandForNewHighlight = previousCount > 0 && highlights.length > previousCount;
+    if (this.collapsePersistence.value && shouldExpandForNewHighlight) {
       this.collapsePersistence.set(false, { persist: true, rerender: false });
     }
     this.highlights = [...highlights];

--- a/src/content/reader/ui/ReaderDialogPanel.ts
+++ b/src/content/reader/ui/ReaderDialogPanel.ts
@@ -10,6 +10,8 @@ import { createReaderSurfaceContent } from '@content/stitch/runtimeSurfaceConten
 import { renderStitchRuntimeSurface } from '@content/stitch/runtimeSurfaceRenderer';
 import { panelStyleSheetManager } from '@content/shared/panels/styleSheetManager';
 import { bindSessionPanelResize } from '@content/shared/panels/sessionPanelResize';
+import { SessionPanelCollapsePersistence } from '@content/shared/panels/sessionPanelCollapsePersistence';
+import { createSessionPanelRenderRoot } from '@content/shared/panels/sessionPanelRoot';
 import { bindSessionItemPreviewExpansion } from '@content/shared/panels/sessionItemPreviewExpansion';
 import { SessionCommentDraftController } from '@content/shared/panels/sessionCommentDrafts';
 import { patchExportDestinationRow } from '@content/shared/exportDestinationDom';
@@ -22,21 +24,25 @@ interface ReaderDialogPanelOptions {
   resolveAssetUrl?: (path: string) => string;
 }
 
-export class ReaderDialogPanel implements UiMountable<
-  HTMLElement | undefined,
-  | {
-      texts?: ReaderPanelTexts;
-      count?: number;
-      hint?: string;
-      highlights?: ReaderPanelHighlight[];
-    }
-  | undefined,
-  HTMLElement
-> {
+export class ReaderDialogPanel
+  implements
+    UiMountable<
+      HTMLElement | undefined,
+      | {
+          texts?: ReaderPanelTexts;
+          count?: number;
+          hint?: string;
+          highlights?: ReaderPanelHighlight[];
+        }
+      | undefined,
+      HTMLElement
+    >
+{
   readonly popupLifecycle = { preserveOnTransientClose: true };
 
   private renderRoot: HTMLElement;
   private readonly popupCoordinator: PopupCoordinator | null;
+  private readonly collapsePersistence: SessionPanelCollapsePersistence;
   private unregisterPopup: (() => void) | null = null;
   private resizeDisposer: (() => void) | null = null;
   private previewExpansionDisposer: (() => void) | null = null;
@@ -53,20 +59,18 @@ export class ReaderDialogPanel implements UiMountable<
     submitDraft: (id, draft) => this.options.callbacks.onSubmitHighlightEdit(id, draft)
   });
   private pendingNoteFocusHighlightId: string | null = null;
-  private collapsed = false;
 
   constructor(private readonly options: ReaderDialogPanelOptions) {
     this.texts = options.texts;
     this.popupCoordinator = resolveContentPopupCoordinator();
-    this.renderRoot = document.createElement('div');
-    this.renderRoot.id = 'aiob-reader-panel';
-    this.renderRoot.style.position = 'fixed';
-    this.renderRoot.style.inset = '0';
-    this.renderRoot.style.zIndex = '2147483647';
-    this.renderRoot.style.pointerEvents = 'none';
+    this.collapsePersistence = new SessionPanelCollapsePersistence({
+      rerender: () => this.rerender()
+    });
+    this.renderRoot = createSessionPanelRenderRoot('aiob-reader-panel');
     const shadow = this.renderRoot.attachShadow({ mode: 'open' });
     panelStyleSheetManager.applyStitchRuntimeStyles(shadow);
     this.rerender();
+    void this.collapsePersistence.restore();
   }
 
   get element(): HTMLElement {
@@ -166,6 +170,7 @@ export class ReaderDialogPanel implements UiMountable<
   }
 
   destroy(): void {
+    this.collapsePersistence.destroy();
     this.unregisterPopup?.();
     this.unregisterPopup = null;
     this.resizeDisposer?.();
@@ -207,7 +212,7 @@ export class ReaderDialogPanel implements UiMountable<
         { id: 'reader:cancel', label: this.texts.cancel, variant: 'ghost' }
       ]
     });
-    if (this.collapsed) {
+    if (this.collapsePersistence.value) {
       content.surfaces.reader.labels.subtitle = '';
     }
     const surface = renderStitchRuntimeSurface({
@@ -224,8 +229,7 @@ export class ReaderDialogPanel implements UiMountable<
           }
         },
         'session:toggleCollapse': () => {
-          this.collapsed = !this.collapsed;
-          this.rerender();
+          this.collapsePersistence.toggle({ persist: true });
         },
         'resource:close': () => this.options.callbacks.onCancel(),
         'reader:delete': (event) => {
@@ -260,21 +264,21 @@ export class ReaderDialogPanel implements UiMountable<
   }
 
   private applyCompatibilityAttributes(surface: HTMLElement): void {
+    const collapsed = this.collapsePersistence.value;
     surface.style.pointerEvents = 'none';
     const modal = surface.querySelector<HTMLElement>('.resource-modal--session');
-    modal?.classList.toggle('is-collapsed', this.collapsed);
+    modal?.classList.toggle('is-collapsed', collapsed);
     const surfaceWindow = surface.querySelector<HTMLElement>('.reader-surface-window');
-    surfaceWindow?.classList.toggle('is-collapsed', this.collapsed);
+    surfaceWindow?.classList.toggle('is-collapsed', collapsed);
     const dialog = surface.querySelector<HTMLElement>('[role="dialog"]');
     if (dialog) {
       dialog.dataset.role = 'dialog-title';
       dialog.style.pointerEvents = 'auto';
     }
     surfaceWindow?.style.setProperty('pointer-events', 'auto');
-    if (this.collapsed && surfaceWindow) {
+    if (collapsed && surfaceWindow) {
       surfaceWindow.addEventListener('click', () => {
-        this.collapsed = false;
-        this.rerender();
+        this.collapsePersistence.set(false, { persist: true });
       });
     }
     surface
@@ -287,13 +291,10 @@ export class ReaderDialogPanel implements UiMountable<
       '[data-action-id="session:toggleCollapse"]'
     );
     if (collapseTrigger) {
-      collapseTrigger.hidden = this.collapsed;
-      collapseTrigger.setAttribute('aria-expanded', this.collapsed ? 'false' : 'true');
-      collapseTrigger.setAttribute(
-        'aria-label',
-        this.collapsed ? 'Expand panel' : 'Collapse panel'
-      );
-      collapseTrigger.textContent = this.collapsed ? '⌃' : '⌄';
+      collapseTrigger.hidden = collapsed;
+      collapseTrigger.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      collapseTrigger.setAttribute('aria-label', collapsed ? 'Expand panel' : 'Collapse panel');
+      collapseTrigger.textContent = collapsed ? '⌃' : '⌄';
     }
     surface.querySelectorAll<HTMLElement>('article[data-highlight-id]').forEach((item) => {
       item.dataset.role = 'highlight-item';
@@ -339,8 +340,8 @@ export class ReaderDialogPanel implements UiMountable<
   private applyHighlights(highlights: ReaderPanelHighlight[]): ReaderPanelHighlight | undefined {
     this.commentDrafts.captureRenderedInputs();
     const previousCount = this.highlights.length;
-    if (this.collapsed && highlights.length > previousCount) {
-      this.collapsed = false;
+    if (this.collapsePersistence.value && highlights.length > previousCount) {
+      this.collapsePersistence.set(false, { persist: true, rerender: false });
     }
     this.highlights = [...highlights];
     this.highlightCount = highlights.length;

--- a/src/content/shared/panels/sessionPanelCollapsePersistence.ts
+++ b/src/content/shared/panels/sessionPanelCollapsePersistence.ts
@@ -1,0 +1,71 @@
+import {
+  loadPersistedSessionPanelLayout,
+  saveSessionPanelCollapsed
+} from './sessionPanelLayoutPersistence';
+
+interface SessionPanelCollapsePersistenceOptions {
+  initialCollapsed?: boolean;
+  restoreFromStorage?: boolean;
+  rerender(): void;
+}
+
+export class SessionPanelCollapsePersistence {
+  private restoreTask: Promise<void> | null = null;
+  private changedBeforeRestore = false;
+  private destroyed = false;
+  private collapsed: boolean;
+
+  constructor(private readonly options: SessionPanelCollapsePersistenceOptions) {
+    this.collapsed = Boolean(options.initialCollapsed);
+  }
+
+  get value(): boolean {
+    return this.collapsed;
+  }
+
+  set(collapsed: boolean, options: { persist?: boolean; rerender?: boolean } = {}): boolean {
+    const changed = this.collapsed !== collapsed;
+    this.collapsed = collapsed;
+    if (options.persist) {
+      this.persist(collapsed);
+    }
+    if (changed && options.rerender !== false) {
+      this.options.rerender();
+    }
+    return changed;
+  }
+
+  toggle(options: { persist?: boolean } = {}): void {
+    this.set(!this.collapsed, options);
+  }
+
+  persist(collapsed: boolean): void {
+    this.changedBeforeRestore = true;
+    saveSessionPanelCollapsed(collapsed);
+  }
+
+  restore(): Promise<void> {
+    if (this.options.restoreFromStorage === false) {
+      return Promise.resolve();
+    }
+    if (!this.restoreTask) {
+      this.restoreTask = loadPersistedSessionPanelLayout()
+        .then((layout) => {
+          if (
+            this.destroyed ||
+            this.changedBeforeRestore ||
+            typeof layout.collapsed !== 'boolean'
+          ) {
+            return;
+          }
+          this.set(layout.collapsed, { rerender: true });
+        })
+        .catch(() => undefined);
+    }
+    return this.restoreTask;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+  }
+}

--- a/src/content/shared/panels/sessionPanelLayoutPersistence.ts
+++ b/src/content/shared/panels/sessionPanelLayoutPersistence.ts
@@ -1,0 +1,124 @@
+import { resolveSessionPanelResizeStorage } from './sessionPanelResizeAdapter';
+import type {
+  SessionPanelLayoutSnapshot,
+  SessionPanelResizeOptions,
+  SessionPanelResizeStorage
+} from './sessionPanelResizeTypes';
+
+const WIDTH_STORAGE_KEY = 'aiob.sessionPanel.width';
+const WIDTH_MAX_STORAGE_KEY = 'aiob.sessionPanel.maxWidth';
+const HEIGHT_STORAGE_KEY = 'aiob.sessionPanel.height';
+const COLLAPSED_STORAGE_KEY = 'aiob.sessionPanel.collapsed';
+
+const persistedPanelLayout: SessionPanelLayoutSnapshot = {
+  width: 0,
+  maxWidth: 0,
+  height: 0,
+  collapsed: null
+};
+let persistedPanelLayoutRevision = 0;
+const storageLoad: WeakMap<
+  SessionPanelResizeStorage,
+  Promise<SessionPanelLayoutSnapshot>
+> = new WeakMap();
+
+function readPositiveInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.round(value) : 0;
+}
+
+function snapshot(): SessionPanelLayoutSnapshot {
+  return { ...persistedPanelLayout };
+}
+
+function saveSessionPanelStorage(
+  storage: SessionPanelResizeStorage,
+  items: Record<string, unknown>
+): void {
+  try {
+    void Promise.resolve(storage.save(items)).catch(() => undefined);
+  } catch {
+    return;
+  }
+}
+
+function loadPersistedPanelLayout(
+  storage: SessionPanelResizeStorage
+): Promise<SessionPanelLayoutSnapshot> {
+  const existingLoad = storageLoad.get(storage);
+  if (existingLoad) {
+    return existingLoad.then(() => snapshot());
+  }
+  const loadRevision = persistedPanelLayoutRevision;
+  const nextLoad = (async () => {
+    try {
+      const items = await storage.load();
+      if (persistedPanelLayoutRevision !== loadRevision) {
+        return snapshot();
+      }
+      persistedPanelLayout.width = readPositiveInteger(items[WIDTH_STORAGE_KEY]);
+      persistedPanelLayout.maxWidth = readPositiveInteger(items[WIDTH_MAX_STORAGE_KEY]);
+      persistedPanelLayout.height = readPositiveInteger(items[HEIGHT_STORAGE_KEY]);
+      const collapsed = items[COLLAPSED_STORAGE_KEY];
+      persistedPanelLayout.collapsed = typeof collapsed === 'boolean' ? collapsed : null;
+    } catch {
+      return snapshot();
+    }
+    return snapshot();
+  })();
+  storageLoad.set(storage, nextLoad);
+  return nextLoad;
+}
+
+export function getSessionPanelLayoutSnapshot(): SessionPanelLayoutSnapshot {
+  return snapshot();
+}
+
+export function updateSessionPanelWidthDraft(width: number): SessionPanelLayoutSnapshot {
+  persistedPanelLayoutRevision += 1;
+  persistedPanelLayout.width = Math.round(width);
+  return snapshot();
+}
+
+export function updateSessionPanelHeightDraft(height: number): SessionPanelLayoutSnapshot {
+  persistedPanelLayoutRevision += 1;
+  persistedPanelLayout.height = Math.round(height);
+  return snapshot();
+}
+
+export async function loadPersistedSessionPanelLayout(
+  options: SessionPanelResizeOptions = { storage: resolveSessionPanelResizeStorage() }
+): Promise<SessionPanelLayoutSnapshot> {
+  return loadPersistedPanelLayout(options.storage);
+}
+
+export function savePersistedSessionPanelWidth(
+  width: number,
+  maxWidth: number,
+  options: SessionPanelResizeOptions
+): void {
+  persistedPanelLayoutRevision += 1;
+  persistedPanelLayout.width = Math.round(width);
+  persistedPanelLayout.maxWidth = Math.round(maxWidth);
+  saveSessionPanelStorage(options.storage, {
+    [WIDTH_STORAGE_KEY]: persistedPanelLayout.width,
+    [WIDTH_MAX_STORAGE_KEY]: persistedPanelLayout.maxWidth
+  });
+}
+
+export function savePersistedSessionPanelHeight(
+  height: number,
+  options: SessionPanelResizeOptions
+): void {
+  persistedPanelLayoutRevision += 1;
+  persistedPanelLayout.height = Math.round(height);
+  saveSessionPanelStorage(options.storage, { [HEIGHT_STORAGE_KEY]: persistedPanelLayout.height });
+}
+
+export function saveSessionPanelCollapsed(
+  collapsed: boolean,
+  options: SessionPanelResizeOptions = { storage: resolveSessionPanelResizeStorage() }
+): void {
+  persistedPanelLayoutRevision += 1;
+  persistedPanelLayout.collapsed = collapsed;
+  saveSessionPanelStorage(options.storage, { [COLLAPSED_STORAGE_KEY]: collapsed });
+}

--- a/src/content/shared/panels/sessionPanelLayoutPersistence.ts
+++ b/src/content/shared/panels/sessionPanelLayoutPersistence.ts
@@ -17,10 +17,18 @@ const persistedPanelLayout: SessionPanelLayoutSnapshot = {
   collapsed: null
 };
 let persistedPanelLayoutRevision = 0;
+const localLayoutRevisions = {
+  width: 0,
+  maxWidth: 0,
+  height: 0,
+  collapsed: 0
+};
 const storageLoad: WeakMap<
   SessionPanelResizeStorage,
   Promise<SessionPanelLayoutSnapshot>
 > = new WeakMap();
+
+type SessionPanelLayoutField = keyof typeof localLayoutRevisions;
 
 function readPositiveInteger(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.round(value) : 0;
@@ -30,12 +38,34 @@ function snapshot(): SessionPanelLayoutSnapshot {
   return { ...persistedPanelLayout };
 }
 
+function commitLocalLayout(fields: SessionPanelLayoutField[]): number {
+  persistedPanelLayoutRevision += 1;
+  for (const field of fields) {
+    localLayoutRevisions[field] = persistedPanelLayoutRevision;
+  }
+  return persistedPanelLayoutRevision;
+}
+
+function canApplyLoadedField(field: SessionPanelLayoutField): boolean {
+  return localLayoutRevisions[field] === 0;
+}
+
 function saveSessionPanelStorage(
   storage: SessionPanelResizeStorage,
-  items: Record<string, unknown>
+  items: Record<string, unknown>,
+  fields: SessionPanelLayoutField[] = []
 ): void {
+  const saveRevision = persistedPanelLayoutRevision;
   try {
-    void Promise.resolve(storage.save(items)).catch(() => undefined);
+    void Promise.resolve(storage.save(items))
+      .then(() => {
+        for (const field of fields) {
+          if (localLayoutRevisions[field] <= saveRevision) {
+            localLayoutRevisions[field] = 0;
+          }
+        }
+      })
+      .catch(() => undefined);
   } catch {
     return;
   }
@@ -55,11 +85,19 @@ function loadPersistedPanelLayout(
       if (persistedPanelLayoutRevision !== loadRevision) {
         return snapshot();
       }
-      persistedPanelLayout.width = readPositiveInteger(items[WIDTH_STORAGE_KEY]);
-      persistedPanelLayout.maxWidth = readPositiveInteger(items[WIDTH_MAX_STORAGE_KEY]);
-      persistedPanelLayout.height = readPositiveInteger(items[HEIGHT_STORAGE_KEY]);
-      const collapsed = items[COLLAPSED_STORAGE_KEY];
-      persistedPanelLayout.collapsed = typeof collapsed === 'boolean' ? collapsed : null;
+      if (canApplyLoadedField('width')) {
+        persistedPanelLayout.width = readPositiveInteger(items[WIDTH_STORAGE_KEY]);
+      }
+      if (canApplyLoadedField('maxWidth')) {
+        persistedPanelLayout.maxWidth = readPositiveInteger(items[WIDTH_MAX_STORAGE_KEY]);
+      }
+      if (canApplyLoadedField('height')) {
+        persistedPanelLayout.height = readPositiveInteger(items[HEIGHT_STORAGE_KEY]);
+      }
+      if (canApplyLoadedField('collapsed')) {
+        const collapsed = items[COLLAPSED_STORAGE_KEY];
+        persistedPanelLayout.collapsed = typeof collapsed === 'boolean' ? collapsed : null;
+      }
     } catch {
       return snapshot();
     }
@@ -74,13 +112,13 @@ export function getSessionPanelLayoutSnapshot(): SessionPanelLayoutSnapshot {
 }
 
 export function updateSessionPanelWidthDraft(width: number): SessionPanelLayoutSnapshot {
-  persistedPanelLayoutRevision += 1;
+  commitLocalLayout(['width']);
   persistedPanelLayout.width = Math.round(width);
   return snapshot();
 }
 
 export function updateSessionPanelHeightDraft(height: number): SessionPanelLayoutSnapshot {
-  persistedPanelLayoutRevision += 1;
+  commitLocalLayout(['height']);
   persistedPanelLayout.height = Math.round(height);
   return snapshot();
 }
@@ -96,29 +134,35 @@ export function savePersistedSessionPanelWidth(
   maxWidth: number,
   options: SessionPanelResizeOptions
 ): void {
-  persistedPanelLayoutRevision += 1;
+  commitLocalLayout(['width', 'maxWidth']);
   persistedPanelLayout.width = Math.round(width);
   persistedPanelLayout.maxWidth = Math.round(maxWidth);
-  saveSessionPanelStorage(options.storage, {
-    [WIDTH_STORAGE_KEY]: persistedPanelLayout.width,
-    [WIDTH_MAX_STORAGE_KEY]: persistedPanelLayout.maxWidth
-  });
+  saveSessionPanelStorage(
+    options.storage,
+    {
+      [WIDTH_STORAGE_KEY]: persistedPanelLayout.width,
+      [WIDTH_MAX_STORAGE_KEY]: persistedPanelLayout.maxWidth
+    },
+    ['width', 'maxWidth']
+  );
 }
 
 export function savePersistedSessionPanelHeight(
   height: number,
   options: SessionPanelResizeOptions
 ): void {
-  persistedPanelLayoutRevision += 1;
+  commitLocalLayout(['height']);
   persistedPanelLayout.height = Math.round(height);
-  saveSessionPanelStorage(options.storage, { [HEIGHT_STORAGE_KEY]: persistedPanelLayout.height });
+  saveSessionPanelStorage(options.storage, { [HEIGHT_STORAGE_KEY]: persistedPanelLayout.height }, [
+    'height'
+  ]);
 }
 
 export function saveSessionPanelCollapsed(
   collapsed: boolean,
   options: SessionPanelResizeOptions = { storage: resolveSessionPanelResizeStorage() }
 ): void {
-  persistedPanelLayoutRevision += 1;
+  commitLocalLayout(['collapsed']);
   persistedPanelLayout.collapsed = collapsed;
-  saveSessionPanelStorage(options.storage, { [COLLAPSED_STORAGE_KEY]: collapsed });
+  saveSessionPanelStorage(options.storage, { [COLLAPSED_STORAGE_KEY]: collapsed }, ['collapsed']);
 }

--- a/src/content/shared/panels/sessionPanelLayoutPersistence.ts
+++ b/src/content/shared/panels/sessionPanelLayoutPersistence.ts
@@ -2,7 +2,8 @@ import { resolveSessionPanelResizeStorage } from './sessionPanelResizeAdapter';
 import type {
   SessionPanelLayoutSnapshot,
   SessionPanelResizeOptions,
-  SessionPanelResizeStorage
+  SessionPanelResizeStorage,
+  SessionPanelStorageItems
 } from './sessionPanelResizeTypes';
 
 const WIDTH_STORAGE_KEY = 'aiob.sessionPanel.width';
@@ -52,7 +53,7 @@ function canApplyLoadedField(field: SessionPanelLayoutField): boolean {
 
 function saveSessionPanelStorage(
   storage: SessionPanelResizeStorage,
-  items: Record<string, unknown>,
+  items: SessionPanelStorageItems,
   fields: SessionPanelLayoutField[] = []
 ): void {
   const saveRevision = persistedPanelLayoutRevision;

--- a/src/content/shared/panels/sessionPanelResize.ts
+++ b/src/content/shared/panels/sessionPanelResize.ts
@@ -1,22 +1,26 @@
 import { resolveSessionPanelResizeStorage } from './sessionPanelResizeAdapter';
+import {
+  getSessionPanelLayoutSnapshot,
+  loadPersistedSessionPanelLayout,
+  savePersistedSessionPanelHeight,
+  savePersistedSessionPanelWidth,
+  saveSessionPanelCollapsed,
+  updateSessionPanelHeightDraft,
+  updateSessionPanelWidthDraft
+} from './sessionPanelLayoutPersistence';
 import type {
-  SessionPanelResizeOptions,
-  SessionPanelResizeStorage
+  SessionPanelLayoutSnapshot,
+  SessionPanelResizeOptions
 } from './sessionPanelResizeTypes';
 
+export { loadPersistedSessionPanelLayout, saveSessionPanelCollapsed };
+
 const MIN_WIDTH_RATIO = 0.6;
-const WIDTH_STORAGE_KEY = 'aiob.sessionPanel.width';
-const WIDTH_MAX_STORAGE_KEY = 'aiob.sessionPanel.maxWidth';
-const HEIGHT_STORAGE_KEY = 'aiob.sessionPanel.height';
 const MIN_VISIBLE_ITEMS = 3;
 const MIN_ITEM_HEIGHT = 56;
 const PANEL_CHROME_HEIGHT = 152;
 const PANEL_DEFAULT_MAX_WIDTH = 576;
 const PANEL_SIDE_GAP = 24;
-let persistedPanelWidth = 0;
-let persistedPanelMaxWidth = 0;
-let persistedPanelHeight = 0;
-const storageLoad: WeakMap<SessionPanelResizeStorage, Promise<void>> = new WeakMap();
 
 interface ResizeState {
   axis: 'width' | 'height';
@@ -39,60 +43,6 @@ function parsePixelValue(value: string): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
-function loadPersistedPanelWidth(storage: SessionPanelResizeStorage): Promise<void> {
-  const existingLoad = storageLoad.get(storage);
-  if (existingLoad) {
-    return existingLoad;
-  }
-  const nextLoad = (async () => {
-    try {
-      const items = await storage.load();
-      const width = items[WIDTH_STORAGE_KEY];
-      if (typeof width === 'number' && Number.isFinite(width) && width > 0) {
-        persistedPanelWidth = Math.round(width);
-      }
-      const maxWidth = items[WIDTH_MAX_STORAGE_KEY];
-      if (typeof maxWidth === 'number' && Number.isFinite(maxWidth) && maxWidth > 0) {
-        persistedPanelMaxWidth = Math.round(maxWidth);
-      }
-      const height = items[HEIGHT_STORAGE_KEY];
-      if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
-        persistedPanelHeight = Math.round(height);
-      }
-    } catch {
-      return;
-    }
-  })();
-  storageLoad.set(storage, nextLoad);
-  return nextLoad;
-}
-
-function saveSessionPanelStorage(
-  storage: SessionPanelResizeStorage,
-  items: Record<string, unknown>
-): void {
-  try {
-    storage.save(items);
-  } catch {
-    return;
-  }
-}
-
-function savePersistedPanelWidth(
-  storage: SessionPanelResizeStorage,
-  width: number,
-  maxWidth = persistedPanelMaxWidth
-): void {
-  saveSessionPanelStorage(storage, {
-    [WIDTH_STORAGE_KEY]: Math.round(width),
-    [WIDTH_MAX_STORAGE_KEY]: Math.round(maxWidth)
-  });
-}
-
-function savePersistedPanelHeight(storage: SessionPanelResizeStorage, height: number): void {
-  saveSessionPanelStorage(storage, { [HEIGHT_STORAGE_KEY]: Math.round(height) });
-}
-
 function minPanelHeight(maxHeight: number): number {
   return Math.min(maxHeight, MIN_VISIBLE_ITEMS * MIN_ITEM_HEIGHT + PANEL_CHROME_HEIGHT);
 }
@@ -112,6 +62,29 @@ function isCollapsedSessionPanel(panel: HTMLElement): boolean {
   return panel.classList.contains('is-collapsed');
 }
 
+function applyPersistedPanelDimensions(panel: HTMLElement): void {
+  const layout = getSessionPanelLayoutSnapshot();
+  if (isCollapsedSessionPanel(panel)) {
+    return;
+  }
+  if (layout.width > 0) {
+    panel.style.width = `${layout.width}px`;
+  }
+  if (layout.height > 0) {
+    applyPanelHeight(panel, layout.height);
+  }
+}
+
+export async function applyPersistedSessionPanelLayout(
+  panel: HTMLElement,
+  options: SessionPanelResizeOptions = { storage: resolveSessionPanelResizeStorage() }
+): Promise<SessionPanelLayoutSnapshot> {
+  applyPersistedPanelDimensions(panel);
+  const layout = await loadPersistedSessionPanelLayout(options);
+  applyPersistedPanelDimensions(panel);
+  return layout;
+}
+
 export async function applyPersistedSessionPanelWidth(
   panel: HTMLElement,
   options: SessionPanelResizeOptions = { storage: resolveSessionPanelResizeStorage() }
@@ -119,12 +92,13 @@ export async function applyPersistedSessionPanelWidth(
   if (isCollapsedSessionPanel(panel)) {
     return;
   }
-  if (persistedPanelWidth > 0) {
-    panel.style.width = `${Math.round(persistedPanelWidth)}px`;
+  const currentLayout = getSessionPanelLayoutSnapshot();
+  if (currentLayout.width > 0) {
+    panel.style.width = `${currentLayout.width}px`;
   }
-  await loadPersistedPanelWidth(options.storage);
-  if (!isCollapsedSessionPanel(panel) && persistedPanelWidth > 0) {
-    panel.style.width = `${Math.round(persistedPanelWidth)}px`;
+  const loadedLayout = await loadPersistedSessionPanelLayout(options);
+  if (!isCollapsedSessionPanel(panel) && loadedLayout.width > 0) {
+    panel.style.width = `${loadedLayout.width}px`;
   }
 }
 
@@ -137,19 +111,15 @@ function viewportPanelMaxWidth(): number {
 }
 
 function resolvePanelMaxWidth(panel: HTMLElement, currentWidth: number): number {
+  const layout = getSessionPanelLayoutSnapshot();
   const computed = window.getComputedStyle(panel);
   const computedMaxWidth = parsePixelValue(computed.maxWidth);
   const tokenMaxWidth = parsePixelValue(computed.getPropertyValue('--session-panel-max-width'));
-  const knownMaxWidth = Math.max(
-    currentWidth,
-    persistedPanelMaxWidth,
-    computedMaxWidth,
-    tokenMaxWidth
-  );
+  const knownMaxWidth = Math.max(currentWidth, layout.maxWidth, computedMaxWidth, tokenMaxWidth);
   if (knownMaxWidth > currentWidth) {
     return knownMaxWidth;
   }
-  if (persistedPanelWidth > 0 && currentWidth <= persistedPanelWidth) {
+  if (layout.width > 0 && currentWidth <= layout.width) {
     return Math.max(currentWidth, viewportPanelMaxWidth());
   }
   return currentWidth;
@@ -165,18 +135,10 @@ export function bindSessionPanelResize(
   if (!panel || !handle || !heightHandle) {
     return () => undefined;
   }
-  if (!isCollapsedSessionPanel(panel) && persistedPanelWidth > 0) {
-    panel.style.width = `${Math.round(persistedPanelWidth)}px`;
-  }
-  if (!isCollapsedSessionPanel(panel) && persistedPanelHeight > 0) {
-    applyPanelHeight(panel, persistedPanelHeight);
-  }
-  void loadPersistedPanelWidth(options.storage).then(() => {
-    if (!isCollapsedSessionPanel(panel) && persistedPanelWidth > 0 && panel.isConnected) {
-      panel.style.width = `${Math.round(persistedPanelWidth)}px`;
-    }
-    if (!isCollapsedSessionPanel(panel) && persistedPanelHeight > 0 && panel.isConnected) {
-      applyPanelHeight(panel, persistedPanelHeight);
+  applyPersistedPanelDimensions(panel);
+  void loadPersistedSessionPanelLayout(options).then(() => {
+    if (panel.isConnected) {
+      applyPersistedPanelDimensions(panel);
     }
   });
 
@@ -188,10 +150,11 @@ export function bindSessionPanelResize(
     document.removeEventListener('pointermove', resize);
     document.removeEventListener('pointerup', stopResize);
     document.removeEventListener('pointercancel', stopResize);
-    if (completedState?.axis === 'width' && persistedPanelWidth > 0) {
-      savePersistedPanelWidth(options.storage, persistedPanelWidth, completedState.maxWidth);
-    } else if (completedState?.axis === 'height' && persistedPanelHeight > 0) {
-      savePersistedPanelHeight(options.storage, persistedPanelHeight);
+    const layout = getSessionPanelLayoutSnapshot();
+    if (completedState?.axis === 'width' && layout.width > 0) {
+      savePersistedSessionPanelWidth(layout.width, completedState.maxWidth, options);
+    } else if (completedState?.axis === 'height' && layout.height > 0) {
+      savePersistedSessionPanelHeight(layout.height, options);
     }
   };
 
@@ -205,8 +168,8 @@ export function bindSessionPanelResize(
         state.minWidth,
         state.maxWidth
       );
-      persistedPanelWidth = Math.round(width);
-      panel.style.width = `${Math.round(width)}px`;
+      const layout = updateSessionPanelWidthDraft(width);
+      panel.style.width = `${layout.width}px`;
       return;
     }
     if (state.axis === 'height' && 'clientY' in event && typeof event.clientY === 'number') {
@@ -215,8 +178,8 @@ export function bindSessionPanelResize(
         state.minHeight,
         state.maxHeight
       );
-      persistedPanelHeight = Math.round(height);
-      applyPanelHeight(panel, persistedPanelHeight);
+      const layout = updateSessionPanelHeightDraft(height);
+      applyPanelHeight(panel, layout.height);
     }
   };
 
@@ -229,7 +192,6 @@ export function bindSessionPanelResize(
     const rect = panel.getBoundingClientRect();
     const currentWidth = Math.max(rect.width, parsePixelValue(panel.style.width), 1);
     const maxWidth = resolvePanelMaxWidth(panel, currentWidth);
-    persistedPanelMaxWidth = Math.max(persistedPanelMaxWidth, Math.round(maxWidth));
     state = {
       axis: 'width',
       startX: event.clientX,

--- a/src/content/shared/panels/sessionPanelResizeTypes.ts
+++ b/src/content/shared/panels/sessionPanelResizeTypes.ts
@@ -1,6 +1,8 @@
+export type SessionPanelStorageItems = Record<string, unknown>;
+
 export interface SessionPanelResizeStorage {
-  load(): Promise<Record<string, unknown>>;
-  save(items: Record<string, unknown>): void | Promise<void>;
+  load(): Promise<SessionPanelStorageItems>;
+  save(items: SessionPanelStorageItems): void | Promise<void>;
 }
 
 export interface SessionPanelResizeOptions {

--- a/src/content/shared/panels/sessionPanelResizeTypes.ts
+++ b/src/content/shared/panels/sessionPanelResizeTypes.ts
@@ -1,8 +1,15 @@
 export interface SessionPanelResizeStorage {
   load(): Promise<Record<string, unknown>>;
-  save(items: Record<string, unknown>): void;
+  save(items: Record<string, unknown>): void | Promise<void>;
 }
 
 export interface SessionPanelResizeOptions {
   storage: SessionPanelResizeStorage;
+}
+
+export interface SessionPanelLayoutSnapshot {
+  width: number;
+  maxWidth: number;
+  height: number;
+  collapsed: boolean | null;
 }

--- a/src/content/shared/panels/sessionPanelRoot.ts
+++ b/src/content/shared/panels/sessionPanelRoot.ts
@@ -1,0 +1,11 @@
+export function createSessionPanelRenderRoot(id?: string): HTMLElement {
+  const root = document.createElement('div');
+  if (id) {
+    root.id = id;
+  }
+  root.style.position = 'fixed';
+  root.style.inset = '0';
+  root.style.zIndex = '2147483647';
+  root.style.pointerEvents = 'none';
+  return root;
+}

--- a/src/content/shared/sessionPanelResizeStorage.ts
+++ b/src/content/shared/sessionPanelResizeStorage.ts
@@ -7,14 +7,20 @@ import type { SessionPanelResizeStorage } from './panels/sessionPanelResizeTypes
 const WIDTH_STORAGE_KEY = 'aiob.sessionPanel.width';
 const WIDTH_MAX_STORAGE_KEY = 'aiob.sessionPanel.maxWidth';
 const HEIGHT_STORAGE_KEY = 'aiob.sessionPanel.height';
+const COLLAPSED_STORAGE_KEY = 'aiob.sessionPanel.collapsed';
 
 function createSessionPanelResizeStorage(area: StorageAreaService): SessionPanelResizeStorage {
   return {
     async load() {
-      return area.getMany([WIDTH_STORAGE_KEY, WIDTH_MAX_STORAGE_KEY, HEIGHT_STORAGE_KEY]);
+      return area.getMany([
+        WIDTH_STORAGE_KEY,
+        WIDTH_MAX_STORAGE_KEY,
+        HEIGHT_STORAGE_KEY,
+        COLLAPSED_STORAGE_KEY
+      ]);
     },
     save(items) {
-      void area.setMany(items);
+      return area.setMany(items);
     }
   };
 }

--- a/src/content/video/ui/VideoDialogPanel.ts
+++ b/src/content/video/ui/VideoDialogPanel.ts
@@ -10,6 +10,8 @@ import { createVideoSurfaceContent } from '@content/stitch/runtimeSurfaceContent
 import { renderStitchRuntimeSurface } from '@content/stitch/runtimeSurfaceRenderer';
 import { panelStyleSheetManager } from '@content/shared/panels/styleSheetManager';
 import { bindSessionPanelResize } from '@content/shared/panels/sessionPanelResize';
+import { SessionPanelCollapsePersistence } from '@content/shared/panels/sessionPanelCollapsePersistence';
+import { createSessionPanelRenderRoot } from '@content/shared/panels/sessionPanelRoot';
 import { bindSessionItemPreviewExpansion } from '@content/shared/panels/sessionItemPreviewExpansion';
 import { SessionCommentDraftController } from '@content/shared/panels/sessionCommentDrafts';
 import { patchExportDestinationRow } from '@content/shared/exportDestinationDom';
@@ -22,16 +24,20 @@ interface VideoDialogPanelOptions {
   initialCollapsed?: boolean;
 }
 
-export class VideoDialogPanel implements UiMountable<
-  HTMLElement | undefined,
-  | { texts?: VideoPanelTexts; count?: number; hint?: string; captures?: VideoPanelCapture[] }
-  | undefined,
-  HTMLElement
-> {
+export class VideoDialogPanel
+  implements
+    UiMountable<
+      HTMLElement | undefined,
+      | { texts?: VideoPanelTexts; count?: number; hint?: string; captures?: VideoPanelCapture[] }
+      | undefined,
+      HTMLElement
+    >
+{
   readonly popupLifecycle = { preserveOnTransientClose: true };
 
   private renderRoot: HTMLElement;
   private readonly popupCoordinator: PopupCoordinator | null;
+  private readonly collapsePersistence: SessionPanelCollapsePersistence;
   private unregisterPopup: (() => void) | null = null;
   private resizeDisposer: (() => void) | null = null;
   private previewExpansionDisposer: (() => void) | null = null;
@@ -47,22 +53,22 @@ export class VideoDialogPanel implements UiMountable<
     getRoot: () => this.renderRoot.shadowRoot,
     submitDraft: (id, draft) => this.options.callbacks.onSubmitCaptureEdit(id, draft)
   });
-  private collapsed = false;
   private keepCollapsedForNextCaptureUpdate = false;
 
   constructor(private readonly options: VideoDialogPanelOptions) {
     this.texts = options.texts;
-    this.collapsed = Boolean(options.initialCollapsed);
-    this.keepCollapsedForNextCaptureUpdate = this.collapsed;
+    this.keepCollapsedForNextCaptureUpdate = Boolean(options.initialCollapsed);
     this.popupCoordinator = resolveContentPopupCoordinator();
-    this.renderRoot = document.createElement('div');
-    this.renderRoot.style.position = 'fixed';
-    this.renderRoot.style.inset = '0';
-    this.renderRoot.style.zIndex = '2147483647';
-    this.renderRoot.style.pointerEvents = 'none';
+    this.collapsePersistence = new SessionPanelCollapsePersistence({
+      initialCollapsed: Boolean(options.initialCollapsed),
+      restoreFromStorage: !options.initialCollapsed,
+      rerender: () => this.rerender()
+    });
+    this.renderRoot = createSessionPanelRenderRoot();
     const shadow = this.renderRoot.attachShadow({ mode: 'open' });
     panelStyleSheetManager.applyStitchRuntimeStyles(shadow);
     this.rerender();
+    void this.collapsePersistence.restore();
   }
 
   get element(): HTMLElement {
@@ -162,12 +168,13 @@ export class VideoDialogPanel implements UiMountable<
   }
 
   collapse(): void {
-    this.collapsed = true;
+    this.collapsePersistence.set(true, { rerender: false });
     this.keepCollapsedForNextCaptureUpdate = true;
     this.rerender();
   }
 
   destroy(): void {
+    this.collapsePersistence.destroy();
     this.unregisterPopup?.();
     this.unregisterPopup = null;
     this.resizeDisposer?.();
@@ -207,7 +214,7 @@ export class VideoDialogPanel implements UiMountable<
         { id: 'video:cancel', label: this.texts.cancel, variant: 'ghost' }
       ]
     });
-    if (this.collapsed) {
+    if (this.collapsePersistence.value) {
       content.surfaces.video.labels.subtitle = '';
     }
     content.surfaces.video.captures = content.surfaces.video.captures.map((capture) =>
@@ -231,8 +238,7 @@ export class VideoDialogPanel implements UiMountable<
           }
         },
         'session:toggleCollapse': () => {
-          this.collapsed = !this.collapsed;
-          this.rerender();
+          this.collapsePersistence.toggle({ persist: true });
         },
         'resource:close': () => this.options.callbacks.onCancel(),
         'video:delete': (event) => {
@@ -256,21 +262,21 @@ export class VideoDialogPanel implements UiMountable<
   }
 
   private applyCompatibilityAttributes(surface: HTMLElement): void {
+    const collapsed = this.collapsePersistence.value;
     surface.style.pointerEvents = 'none';
     const modal = surface.querySelector<HTMLElement>('.resource-modal--session');
-    modal?.classList.toggle('is-collapsed', this.collapsed);
+    modal?.classList.toggle('is-collapsed', collapsed);
     const surfaceWindow = surface.querySelector<HTMLElement>('.video-surface-window');
-    surfaceWindow?.classList.toggle('is-collapsed', this.collapsed);
+    surfaceWindow?.classList.toggle('is-collapsed', collapsed);
     const dialog = surface.querySelector<HTMLElement>('[role="dialog"]');
     if (dialog) {
       dialog.dataset.element = 'dialog';
       dialog.style.pointerEvents = 'auto';
     }
     surfaceWindow?.style.setProperty('pointer-events', 'auto');
-    if (this.collapsed && surfaceWindow) {
+    if (collapsed && surfaceWindow) {
       surfaceWindow.addEventListener('click', () => {
-        this.collapsed = false;
-        this.rerender();
+        this.collapsePersistence.set(false, { persist: true });
       });
     }
     surface
@@ -289,13 +295,10 @@ export class VideoDialogPanel implements UiMountable<
       '[data-action-id="session:toggleCollapse"]'
     );
     if (collapseTrigger) {
-      collapseTrigger.hidden = this.collapsed;
-      collapseTrigger.setAttribute('aria-expanded', this.collapsed ? 'false' : 'true');
-      collapseTrigger.setAttribute(
-        'aria-label',
-        this.collapsed ? 'Expand panel' : 'Collapse panel'
-      );
-      collapseTrigger.textContent = this.collapsed ? '⌃' : '⌄';
+      collapseTrigger.hidden = collapsed;
+      collapseTrigger.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+      collapseTrigger.setAttribute('aria-label', collapsed ? 'Expand panel' : 'Collapse panel');
+      collapseTrigger.textContent = collapsed ? '⌃' : '⌄';
     }
     surface.querySelectorAll<HTMLElement>('article[data-capture-id]').forEach((item) => {
       item.dataset.role = 'capture-item';
@@ -335,11 +338,11 @@ export class VideoDialogPanel implements UiMountable<
   private applyCaptures(captures: VideoPanelCapture[]): void {
     this.commentDrafts.captureRenderedInputs();
     if (
-      this.collapsed &&
+      this.collapsePersistence.value &&
       captures.length > this.captures.length &&
       !this.keepCollapsedForNextCaptureUpdate
     ) {
-      this.collapsed = false;
+      this.collapsePersistence.set(false, { persist: true, rerender: false });
     }
     this.keepCollapsedForNextCaptureUpdate = false;
     this.captures = [...captures];

--- a/src/content/video/ui/VideoDialogPanel.ts
+++ b/src/content/video/ui/VideoDialogPanel.ts
@@ -337,9 +337,11 @@ export class VideoDialogPanel
 
   private applyCaptures(captures: VideoPanelCapture[]): void {
     this.commentDrafts.captureRenderedInputs();
+    const shouldExpandForNewCapture =
+      this.captures.length > 0 && captures.length > this.captures.length;
     if (
       this.collapsePersistence.value &&
-      captures.length > this.captures.length &&
+      shouldExpandForNewCapture &&
       !this.keepCollapsedForNextCaptureUpdate
     ) {
       this.collapsePersistence.set(false, { persist: true, rerender: false });
@@ -359,9 +361,8 @@ export class VideoDialogPanel
   }
 
   private formatCounter(count: number): string {
-    if (count <= 0) {
-      return this.texts.counterZero;
-    }
-    return this.texts.counter.replace('{count}', String(count));
+    return count <= 0
+      ? this.texts.counterZero
+      : this.texts.counter.replace('{count}', String(count));
   }
 }

--- a/tests/unit/content/reader/ReaderDialogPanel.test.ts
+++ b/tests/unit/content/reader/ReaderDialogPanel.test.ts
@@ -239,6 +239,38 @@ describe('ReaderDialogPanel', () => {
     panel.destroy();
   });
 
+  it('keeps restored collapse when the initial highlight list hydrates', async () => {
+    await testPlatformHarness.storage.local.set('aiob.sessionPanel.collapsed', true);
+    const panel = new ReaderDialogPanel({
+      texts: createReaderPanelTexts(),
+      callbacks: createReaderPanelCallbacks()
+    });
+    const first = createHighlight({ id: 'h-1', index: 1 });
+    const second = createHighlight({ id: 'h-2', index: 2 });
+    panel.show();
+
+    await flushPanelPersistence();
+    panel.setHighlights([first]);
+
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(true);
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(true);
+
+    panel.setHighlights([first, second]);
+
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(false);
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(false);
+
+    panel.destroy();
+  });
+
   it('focuses reader controls through the shared content dialog focus helper', async () => {
     const { focusContentDialogElement } = await import(
       '../../../../src/ui/hosts/content/contentDialogFocus'

--- a/tests/unit/content/reader/ReaderDialogPanel.test.ts
+++ b/tests/unit/content/reader/ReaderDialogPanel.test.ts
@@ -7,6 +7,7 @@ import type {
   ReaderPanelHighlight,
   ReaderPanelTexts
 } from '../../../../src/content/reader/application/readerPanelModel';
+import { testPlatformHarness } from '../../../setup/globalSetup';
 
 vi.mock('focus-trap', () => ({
   createFocusTrap: () => ({
@@ -61,6 +62,10 @@ function createHighlight(overrides: Partial<ReaderPanelHighlight> = {}): ReaderP
     timestamp: Date.now(),
     ...overrides
   };
+}
+
+function flushPanelPersistence(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('ReaderDialogPanel', () => {
@@ -204,9 +209,40 @@ describe('ReaderDialogPanel', () => {
     panel.destroy();
   });
 
+  it('restores and persists the reader floating panel collapsed state', async () => {
+    await testPlatformHarness.storage.local.set('aiob.sessionPanel.collapsed', true);
+    const panel = new ReaderDialogPanel({
+      texts: createReaderPanelTexts(),
+      callbacks: createReaderPanelCallbacks()
+    });
+    panel.show();
+
+    await flushPanelPersistence();
+
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(true);
+
+    panel.element.shadowRoot
+      ?.querySelector<HTMLElement>('.reader-surface-window')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(false);
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(false);
+
+    panel.destroy();
+  });
+
   it('focuses reader controls through the shared content dialog focus helper', async () => {
-    const { focusContentDialogElement } =
-      await import('../../../../src/ui/hosts/content/contentDialogFocus');
+    const { focusContentDialogElement } = await import(
+      '../../../../src/ui/hosts/content/contentDialogFocus'
+    );
     const panel = new ReaderDialogPanel({
       texts: createReaderPanelTexts(),
       callbacks: createReaderPanelCallbacks()

--- a/tests/unit/content/sessionPanelResize.test.ts
+++ b/tests/unit/content/sessionPanelResize.test.ts
@@ -5,8 +5,11 @@ import { asType } from '../../utils/typeHelpers';
 
 type SessionPanelStorageItems = Partial<
   Record<
-    'aiob.sessionPanel.width' | 'aiob.sessionPanel.maxWidth' | 'aiob.sessionPanel.height',
-    number
+    | 'aiob.sessionPanel.width'
+    | 'aiob.sessionPanel.maxWidth'
+    | 'aiob.sessionPanel.height'
+    | 'aiob.sessionPanel.collapsed',
+    number | boolean
   >
 >;
 
@@ -103,7 +106,7 @@ describe('session panel resize persistence', () => {
     vi.restoreAllMocks();
   });
 
-  it('applies in-memory width immediately and storage width after async load', async () => {
+  it('keeps committed in-memory width when an older async storage load resolves later', async () => {
     const loadStorage: { current?: (items: SessionPanelStorageItems) => void } = {};
     const storage = createSessionPanelStorage(() => {
       return new Promise((resolve) => {
@@ -126,7 +129,25 @@ describe('session panel resize persistence', () => {
     expect(loadStorage.current).toBeInstanceOf(Function);
     loadStorage.current?.({ 'aiob.sessionPanel.width': 512, 'aiob.sessionPanel.maxWidth': 576 });
     await loadPromise;
-    expect(secondPanel.style.width).toBe('512px');
+    expect(secondPanel.style.width).toBe('440px');
+  });
+
+  it('applies stored width after async load when no local resize wins the race', async () => {
+    const loadStorage: { current?: (items: SessionPanelStorageItems) => void } = {};
+    const storage = createSessionPanelStorage(() => {
+      return new Promise((resolve) => {
+        loadStorage.current = resolve;
+      });
+    });
+    const { applyPersistedSessionPanelWidth } = await importResizeModule();
+    const panel = document.createElement('section');
+
+    const loadPromise = applyPersistedSessionPanelWidth(panel, { storage });
+
+    expect(loadStorage.current).toBeInstanceOf(Function);
+    loadStorage.current?.({ 'aiob.sessionPanel.width': 512, 'aiob.sessionPanel.maxWidth': 576 });
+    await loadPromise;
+    expect(panel.style.width).toBe('512px');
   });
 
   it('returns cleanup functions for complete or missing resize surfaces', async () => {
@@ -178,6 +199,49 @@ describe('session panel resize persistence', () => {
 
     expect(storage.save).toHaveBeenCalledTimes(1);
     expect(storage.save).toHaveBeenCalledWith({ 'aiob.sessionPanel.height': 420 });
+  });
+
+  it('loads persisted layout dimensions and collapsed state together', async () => {
+    const storage = createSessionPanelStorage(() =>
+      Promise.resolve({
+        'aiob.sessionPanel.width': 512,
+        'aiob.sessionPanel.maxWidth': 576,
+        'aiob.sessionPanel.height': 480,
+        'aiob.sessionPanel.collapsed': true
+      })
+    );
+    const { applyPersistedSessionPanelLayout } = await importResizeModule();
+    const fixture = createSurfaceFixture();
+
+    const layout = await applyPersistedSessionPanelLayout(fixture.panel, { storage });
+
+    expect(layout).toEqual({
+      width: 512,
+      maxWidth: 576,
+      height: 480,
+      collapsed: true
+    });
+    expect(fixture.panel.style.width).toBe('512px');
+    expect(fixture.panel.style.height).toBe('480px');
+    expect(fixture.panel.style.getPropertyValue('--aiob-session-panel-max-height')).toBe('90vh');
+  });
+
+  it('persists collapsed state and returns the current in-memory snapshot after an earlier load', async () => {
+    const storage = createSessionPanelStorage(() =>
+      Promise.resolve({ 'aiob.sessionPanel.collapsed': false })
+    );
+    const { loadPersistedSessionPanelLayout, saveSessionPanelCollapsed } =
+      await importResizeModule();
+
+    await expect(loadPersistedSessionPanelLayout({ storage })).resolves.toMatchObject({
+      collapsed: false
+    });
+    saveSessionPanelCollapsed(true, { storage });
+
+    expect(storage.save).toHaveBeenCalledWith({ 'aiob.sessionPanel.collapsed': true });
+    await expect(loadPersistedSessionPanelLayout({ storage })).resolves.toMatchObject({
+      collapsed: true
+    });
   });
 
   it('commits pointercancel once and removes active document listeners', async () => {

--- a/tests/unit/content/sessionPanelResize.test.ts
+++ b/tests/unit/content/sessionPanelResize.test.ts
@@ -244,6 +244,29 @@ describe('session panel resize persistence', () => {
     });
   });
 
+  it('keeps a locally committed collapsed state when a later storage load returns stale data', async () => {
+    let resolveSave = (): void => undefined;
+    const storage = createSessionPanelStorage(() =>
+      Promise.resolve({ 'aiob.sessionPanel.collapsed': false })
+    );
+    storage.save.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
+    const { loadPersistedSessionPanelLayout, saveSessionPanelCollapsed } =
+      await importResizeModule();
+
+    saveSessionPanelCollapsed(true, { storage });
+
+    expect(storage.save).toHaveBeenCalledWith({ 'aiob.sessionPanel.collapsed': true });
+    await expect(loadPersistedSessionPanelLayout({ storage })).resolves.toMatchObject({
+      collapsed: true
+    });
+    resolveSave();
+  });
+
   it('commits pointercancel once and removes active document listeners', async () => {
     const storage = createSessionPanelStorage();
     const { bindSessionPanelResize } = await importResizeModule();

--- a/tests/unit/content/video/VideoDialogPanel.test.ts
+++ b/tests/unit/content/video/VideoDialogPanel.test.ts
@@ -7,6 +7,7 @@ import type {
   VideoPanelCapture
 } from '@content/video/application/videoPanelModel';
 import { VideoDialogPanel } from '@content/video/ui/VideoDialogPanel';
+import { testPlatformHarness } from '../../../setup/globalSetup';
 
 const callbacks: VideoPanelCallbacks = {
   onAddCapture: vi.fn(),
@@ -49,6 +50,10 @@ function createCapture(overrides: Partial<VideoPanelCapture> = {}): VideoPanelCa
     shareUrl: 'https://example.com?t=42',
     ...overrides
   };
+}
+
+function flushPanelPersistence(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('VideoDialogPanel', () => {
@@ -333,6 +338,42 @@ describe('VideoDialogPanel', () => {
     );
 
     panel.destroy();
+  });
+
+  it('restores user-collapsed video floating panels from local storage', async () => {
+    await testPlatformHarness.storage.local.set('aiob.sessionPanel.collapsed', true);
+    const panel = new VideoDialogPanel({ callbacks, texts });
+    panel.show();
+
+    await flushPanelPersistence();
+
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(true);
+
+    panel.destroy();
+  });
+
+  it('persists user collapse without persisting programmatic video capture collapse', async () => {
+    const programmaticPanel = new VideoDialogPanel({ callbacks, texts });
+    programmaticPanel.show();
+    programmaticPanel.collapse();
+
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(
+      undefined
+    );
+    programmaticPanel.destroy();
+
+    const userPanel = new VideoDialogPanel({ callbacks, texts });
+    userPanel.show();
+    userPanel.element.shadowRoot
+      ?.querySelector<HTMLButtonElement>('[data-action-id="session:toggleCollapse"]')
+      ?.click();
+
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(true);
+    userPanel.destroy();
   });
 
   it('renders text fragments below timestamps with reader-style numbering', () => {

--- a/tests/unit/content/video/VideoDialogPanel.test.ts
+++ b/tests/unit/content/video/VideoDialogPanel.test.ts
@@ -356,6 +356,35 @@ describe('VideoDialogPanel', () => {
     panel.destroy();
   });
 
+  it('keeps restored collapse when the initial capture list hydrates', async () => {
+    await testPlatformHarness.storage.local.set('aiob.sessionPanel.collapsed', true);
+    const panel = new VideoDialogPanel({ callbacks, texts });
+    const first = createCapture({ id: 'capture-1', index: 1 });
+    const second = createCapture({ id: 'capture-2', index: 2 });
+    panel.show();
+
+    await flushPanelPersistence();
+    panel.setCaptures([first]);
+
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(true);
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(true);
+
+    panel.setCaptures([first, second]);
+
+    expect(
+      panel.element.shadowRoot
+        ?.querySelector('.resource-modal--session')
+        ?.classList.contains('is-collapsed')
+    ).toBe(false);
+    expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(false);
+
+    panel.destroy();
+  });
+
   it('persists user collapse without persisting programmatic video capture collapse', async () => {
     const programmaticPanel = new VideoDialogPanel({ callbacks, texts });
     programmaticPanel.show();


### PR DESCRIPTION
## Summary
- persist Reader/Video session panel width, height, and collapsed state through shared layout persistence
- preserve restored collapsed state during initial highlight/capture hydration
- guard pending local layout writes from stale storage loads

## Verification
- npm run build:dev
- npm run typecheck
- npm run lint (0 errors, 140 existing warnings)
- npm run test:unit (305 files, 1686 tests)
- manual Playwright harness smoke for resize/collapse/reopen/restore