### PR TITLE
fix(analytics): route GA events through queue

### DIFF
--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -5,7 +5,10 @@
 
 import { registry, TOKENS } from '../shared/di';
 import { createErrorHandler } from '../shared/errors/errorHandler';
-import { configureAnalyticsConfigManager } from '../shared/errors/analytics/analyticsConfig';
+import {
+  configureAnalyticsConfigManager,
+  watchAnalyticsConfigStorage
+} from '../shared/errors/analytics/analyticsConfig';
 import { initializeErrorAnalytics } from '../shared/errors/analytics';
 import { registerGlobalErrorBoundary } from '../shared/errors/globalErrorBoundary';
 import {
@@ -13,11 +16,13 @@ import {
   createGlobalStateManager
 } from '../shared/state/globalStateManager';
 import { configureUsageStatsStorage, createUsageStatsStore } from './services/usageStats';
+import { clearQueuedUsageAnalyticsEventsIfConsentRevoked } from './services/analyticsEvents';
 import { configureI18nStorage } from '@i18n';
 import type { StorageService } from '../platform/interfaces/storage';
 
 let backgroundDependencyStorage: StorageService | null = null;
 let cleanupBackgroundErrorBoundary: (() => void) | null = null;
+let cleanupAnalyticsConfigStorageWatch: (() => void) | null = null;
 
 export function configureBackgroundDependencyStorage(storage: StorageService): void {
   backgroundDependencyStorage = storage;
@@ -47,6 +52,11 @@ export function bootstrapBackgroundDependencies(storage?: StorageService): void 
   configureGlobalStateManagerStorage(resolvedStorage);
   configureI18nStorage(resolvedStorage.sync);
   configureUsageStatsStorage(resolvedStorage);
+
+  cleanupAnalyticsConfigStorageWatch?.();
+  cleanupAnalyticsConfigStorageWatch = watchAnalyticsConfigStorage((config) => {
+    clearQueuedUsageAnalyticsEventsIfConsentRevoked(config);
+  });
 
   // 注册错误处理器
   const errorHandler = createErrorHandler();
@@ -92,6 +102,11 @@ export function bootstrapBackgroundDependencies(storage?: StorageService): void 
 export function cleanupBackgroundDependencies(): void {
   console.log('[Background] Cleaning up dependencies...');
 
+  cleanupBackgroundErrorBoundary?.();
+  cleanupBackgroundErrorBoundary = null;
+  cleanupAnalyticsConfigStorageWatch?.();
+  cleanupAnalyticsConfigStorageWatch = null;
+
   try {
     // 释放使用统计存储
     if (registry.has(TOKENS.usageStatsStore)) {
@@ -107,9 +122,6 @@ export function cleanupBackgroundDependencies(): void {
     if (registry.has(TOKENS.errorHandler)) {
       registry.dispose(TOKENS.errorHandler);
     }
-
-    cleanupBackgroundErrorBoundary?.();
-    cleanupBackgroundErrorBoundary = null;
 
     console.log('[Background] Dependencies cleaned up successfully');
   } catch (error) {

--- a/src/background/services/analyticsEvents.ts
+++ b/src/background/services/analyticsEvents.ts
@@ -1,11 +1,17 @@
 import {
   getAnalyticsConfigManager,
   initializeAnalyticsConfig,
-  refreshAnalyticsConfig
+  refreshAnalyticsConfig,
+  type AnalyticsConfig
 } from '../../shared/errors/analytics/analyticsConfig';
 import {
   buildAnalyticsTransportPayload,
-  sendAnalyticsTransportEvent
+  createAnalyticsEventQueue,
+  sendAnalyticsTransportEvent,
+  type AnalyticsEventName,
+  type AnalyticsEventQueue,
+  type AnalyticsEventQueueOptions,
+  type AnalyticsTransportResult
 } from '../../shared/analytics';
 import { getService } from '../../shared/di';
 import { TOKENS } from '../../shared/di/tokens';
@@ -17,6 +23,16 @@ import {
 } from '../../shared/types/analytics';
 
 let initializationPromise: Promise<void> | null = null;
+let usageEventQueue: AnalyticsEventQueue | null = null;
+let usageEventQueueVersion = 'unknown';
+
+type QueuedAnalyticsEventParams = Parameters<NonNullable<AnalyticsEventQueueOptions['send']>>[1];
+type UsageAnalyticsConsentSnapshot = {
+  enabled?: boolean;
+  userConsent?: {
+    analytics?: boolean;
+  };
+};
 
 async function ensureAnalyticsReady(): Promise<void> {
   if (initializationPromise === null) {
@@ -32,9 +48,10 @@ async function ensureAnalyticsReady(): Promise<void> {
 
   try {
     await initializationPromise;
-  } catch {
+  } catch (error) {
     // Reset on failure so we can retry next time
     initializationPromise = null;
+    throw error;
   }
 }
 
@@ -64,6 +81,86 @@ function resolveExtensionVersion(): string {
   }
 }
 
+function getUsageEventQueue(extensionVersion: string): AnalyticsEventQueue {
+  if (usageEventQueue && usageEventQueueVersion === extensionVersion) {
+    return usageEventQueue;
+  }
+
+  usageEventQueueVersion = extensionVersion;
+  usageEventQueue = createAnalyticsEventQueue({
+    getConfig: () => getAnalyticsConfigManager().getConfig(),
+    send: (eventName, params, config) =>
+      sendQueuedUsageEvent(eventName, params, config, extensionVersion)
+  });
+  return usageEventQueue;
+}
+
+export function clearQueuedUsageAnalyticsEvents(): void {
+  usageEventQueue?.clear();
+}
+
+export function clearQueuedUsageAnalyticsEventsIfConsentRevoked(
+  config: UsageAnalyticsConsentSnapshot
+): void {
+  if (config.enabled !== true || config.userConsent?.analytics !== true) {
+    clearQueuedUsageAnalyticsEvents();
+  }
+}
+
+async function sendQueuedUsageEvent(
+  eventName: AnalyticsEventName,
+  params: QueuedAnalyticsEventParams,
+  config: AnalyticsConfig,
+  extensionVersion: string
+): Promise<AnalyticsTransportResult> {
+  const result = await sendAnalyticsTransportEvent(eventName, params, config, {
+    extensionVersion
+  });
+  logAnalyticsTransportResult(eventName, params, config, extensionVersion, result);
+  return result;
+}
+
+function logAnalyticsTransportResult(
+  eventName: AnalyticsEventName,
+  params: QueuedAnalyticsEventParams,
+  config: AnalyticsConfig,
+  extensionVersion: string,
+  result: AnalyticsTransportResult
+): void {
+  if (result.status === 'sent') {
+    const payload = buildAnalyticsTransportPayload(eventName, params, config, {
+      extensionVersion
+    });
+    const logPayload = {
+      eventName,
+      params: payload?.events[0]?.params ?? {},
+      transportMode: result.transportMode,
+      responseStatus: result.responseStatus,
+      ...(result.debugResponse !== undefined ? { response: result.debugResponse } : {})
+    };
+
+    if (result.transportMode === 'directDebug') {
+      console.info('[analytics-events] Event sent (debug):', logPayload);
+    } else {
+      console.info('[analytics-events] Event sent:', logPayload);
+    }
+    return;
+  }
+
+  if (result.status === 'failed') {
+    if (result.responseStatus !== undefined) {
+      console.warn(`[analytics-events] Analytics transport failed: ${result.responseStatus}`);
+    } else {
+      console.warn('[analytics-events] Failed to send analytics usage event:', result.error);
+    }
+    return;
+  }
+
+  if (result.reason === 'missing_client_id') {
+    console.warn('[analytics-events] Missing analytics client id.');
+  }
+}
+
 export async function trackUsageEvent<EventName extends UsageEventName>(
   eventName: EventName,
   params?: UsageEventParamMap[EventName]
@@ -88,51 +185,17 @@ export async function trackUsageEvent<EventName extends UsageEventName>(
 
   const hasAnalyticsConsent = config.userConsent?.analytics === true;
   if (!hasAnalyticsConsent) {
+    clearQueuedUsageAnalyticsEvents();
     return;
   }
 
-  const sessionId = await ensureSessionId();
+  await ensureSessionId();
   const extensionVersion = resolveExtensionVersion();
-  const activeConfig = sessionId
-    ? { ...getAnalyticsConfigManager().getConfig(), sessionId }
-    : getAnalyticsConfigManager().getConfig();
+  const queue = getUsageEventQueue(extensionVersion);
 
   try {
-    const result = await sendAnalyticsTransportEvent(eventName, params, activeConfig, {
-      extensionVersion
-    });
-
-    if (result.status === 'sent') {
-      const payload = buildAnalyticsTransportPayload(eventName, params, activeConfig, {
-        extensionVersion
-      });
-      const logPayload = {
-        eventName,
-        params: payload?.events[0]?.params ?? {},
-        transportMode: result.transportMode,
-        responseStatus: result.responseStatus,
-        ...(result.debugResponse !== undefined ? { response: result.debugResponse } : {})
-      };
-
-      if (result.transportMode === 'directDebug') {
-        console.info('[analytics-events] Event sent (debug):', logPayload);
-      } else {
-        console.info('[analytics-events] Event sent:', logPayload);
-      }
-      return;
-    }
-
-    if (result.status === 'failed') {
-      if (result.responseStatus !== undefined) {
-        console.warn(`[analytics-events] Analytics transport failed: ${result.responseStatus}`);
-      } else {
-        console.warn('[analytics-events] Failed to send analytics usage event:', result.error);
-      }
-      return;
-    }
-
-    if (result.reason === 'missing_client_id') {
-      console.warn('[analytics-events] Missing analytics client id.');
+    if (queue.enqueue(eventName, params)) {
+      await queue.flush();
     }
   } catch (error) {
     console.warn('[analytics-events] Failed to send analytics usage event:', error);

--- a/src/shared/analytics/analyticsQueue.ts
+++ b/src/shared/analytics/analyticsQueue.ts
@@ -104,6 +104,7 @@ export function createAnalyticsEventQueue(
 
     clear() {
       entries = [];
+      lastFlushAt = 0;
     },
 
     size() {
@@ -119,6 +120,9 @@ export function createAnalyticsEventQueue(
 function hasConsentForEvent(config: AnalyticsConfig, eventName: AnalyticsEventName): boolean {
   if (!config.enabled) {
     return false;
+  }
+  if (!config.userConsent) {
+    return true;
   }
   if (eventName === 'extension_error') {
     return config.userConsent?.errorReporting === true;

--- a/src/shared/errors/analytics/googleAnalyticsReporter.ts
+++ b/src/shared/errors/analytics/googleAnalyticsReporter.ts
@@ -9,7 +9,11 @@ import { ErrorReporter, AppError } from '../types';
 import { parseErrorCode } from '../errorCodes';
 import { sanitizeErrorForAnalytics } from './dataSanitizer';
 import { DEFAULT_ANALYTICS_CONFIG, type AnalyticsConfig } from './analyticsConfig';
-import { sendAnalyticsTransportEvent } from '../../analytics';
+import {
+  createAnalyticsEventQueue,
+  sendAnalyticsTransportEvent,
+  type AnalyticsEventQueue
+} from '../../analytics';
 import { getService } from '../../di';
 import { TOKENS } from '../../di/tokens';
 import type { PlatformServices } from '@platform/types';
@@ -22,6 +26,8 @@ export interface GoogleAnalyticsConfig extends Pick<
   debugMode?: boolean;
   sessionId?: string;
   clientId?: string;
+  reportingInterval?: number;
+  batchSize?: number;
 }
 
 // GA4 事件参数接口
@@ -40,6 +46,7 @@ export class GoogleAnalyticsReporter implements ErrorReporter {
   private clientId: string;
   private sessionId: string;
   private extensionVersion: string;
+  private eventQueue: AnalyticsEventQueue;
   private browserInfo: { name?: string; version?: string } = {};
 
   constructor(config: GoogleAnalyticsConfig) {
@@ -51,9 +58,18 @@ export class GoogleAnalyticsReporter implements ErrorReporter {
       transportMode: config.transportMode ?? DEFAULT_ANALYTICS_CONFIG.transportMode,
       ...(config.proxyEndpoint ? { proxyEndpoint: config.proxyEndpoint } : {}),
       clientId: this.clientId,
-      sessionId: this.sessionId
+      sessionId: this.sessionId,
+      reportingInterval: config.reportingInterval ?? DEFAULT_ANALYTICS_CONFIG.reportingInterval,
+      batchSize: config.batchSize ?? DEFAULT_ANALYTICS_CONFIG.batchSize
     };
     this.extensionVersion = this.getExtensionVersion();
+    this.eventQueue = createAnalyticsEventQueue({
+      getConfig: () => this.createTransportConfig(),
+      send: (eventName, params, transportConfig) =>
+        sendAnalyticsTransportEvent(eventName, params, transportConfig, {
+          extensionVersion: this.extensionVersion
+        })
+    });
     this.initializeBrowserInfo();
   }
 
@@ -65,19 +81,18 @@ export class GoogleAnalyticsReporter implements ErrorReporter {
     try {
       const sanitizedError = sanitizeErrorForAnalytics(error);
       const eventParams = this.createErrorEventParams(sanitizedError);
-      const result = await sendAnalyticsTransportEvent(
-        'extension_error',
-        eventParams,
-        this.createTransportConfig(),
-        { extensionVersion: this.extensionVersion }
-      );
+      const enqueued = this.eventQueue.enqueue('extension_error', eventParams);
+      if (!enqueued) {
+        return;
+      }
+      const result = await this.eventQueue.flush();
 
-      if (result.status === 'failed') {
+      if (result.failed > 0) {
         console.warn('[GA Reporter] Analytics transport failed:', result);
         return;
       }
 
-      if (this.config.debugMode) {
+      if (this.config.debugMode && result.sent > 0) {
         console.log('[GA Reporter] Error reported:', {
           code: eventParams.error_code,
           domain: eventParams.error_domain,
@@ -200,9 +215,10 @@ export class GoogleAnalyticsReporter implements ErrorReporter {
       ...(this.config.proxyEndpoint ? { proxyEndpoint: this.config.proxyEndpoint } : {}),
       clientId: this.clientId,
       sessionId: this.sessionId,
-      reportingInterval: DEFAULT_ANALYTICS_CONFIG.reportingInterval,
+      reportingInterval:
+        this.config.reportingInterval ?? DEFAULT_ANALYTICS_CONFIG.reportingInterval,
       maxErrorsPerSession: DEFAULT_ANALYTICS_CONFIG.maxErrorsPerSession,
-      batchSize: DEFAULT_ANALYTICS_CONFIG.batchSize
+      batchSize: this.config.batchSize ?? DEFAULT_ANALYTICS_CONFIG.batchSize
     };
   }
 

--- a/src/shared/errors/analytics/index.ts
+++ b/src/shared/errors/analytics/index.ts
@@ -74,6 +74,8 @@ export async function initializeErrorAnalytics(
         enabled: config.enabled,
         debugMode: config.debugMode,
         transportMode: config.transportMode,
+        reportingInterval: config.reportingInterval,
+        batchSize: config.batchSize,
         ...(config.proxyEndpoint ? { proxyEndpoint: config.proxyEndpoint } : {}),
         ...(config.clientId !== undefined && { clientId: config.clientId }),
         ...(config.sessionId !== undefined && { sessionId: config.sessionId })

--- a/tests/unit/background/analyticsEvents.test.ts
+++ b/tests/unit/background/analyticsEvents.test.ts
@@ -32,6 +32,8 @@ type AnalyticsConfigSnapshot = {
   clientId?: string;
   sessionId?: string;
   debugMode?: boolean;
+  reportingInterval?: number;
+  batchSize?: number;
 };
 
 function createAnalyticsConfig(
@@ -46,6 +48,8 @@ function createAnalyticsConfig(
     clientId: 'client-1',
     sessionId: 'session-1',
     debugMode: false,
+    reportingInterval: 30000,
+    batchSize: 10,
     ...overrides
   };
 }
@@ -80,6 +84,7 @@ describe('analyticsEvents', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    fetchMock.mockReset();
     vi.unstubAllGlobals();
     vi.stubGlobal('fetch', fetchMock);
     const initialConfig = createAnalyticsConfig();
@@ -201,6 +206,89 @@ describe('analyticsEvents', () => {
 
     expect(refreshAnalyticsConfigMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends usage events through the configured queue interval and batch size', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(100000);
+      const queuedConfig = createAnalyticsConfig({
+        reportingInterval: 60000,
+        batchSize: 1
+      });
+      getConfigMock.mockReturnValue(queuedConfig);
+      refreshAnalyticsConfigMock.mockResolvedValue(queuedConfig);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        clone: () => ({ text: () => Promise.resolve('') })
+      });
+
+      const { trackUsageEvent } = await import('../../../src/background/services/analyticsEvents');
+      await trackUsageEvent('support_like_clicked', { variant: 'first' });
+      await trackUsageEvent('support_dislike_clicked');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(161000);
+      await trackUsageEvent('support_review_link_clicked', { variant: 'returning' });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [, requestInit] = fetchMock.mock.calls[1] ?? [];
+      expect(String(requestInit?.body)).toContain('"name":"support_dislike_clicked"');
+      expect(String(requestInit?.body)).not.toContain('"name":"support_review_link_clicked"');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears queued usage events when analytics consent is revoked before a later restore', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(200000);
+      let storedConfig = createAnalyticsConfig({
+        reportingInterval: 60000,
+        batchSize: 1
+      });
+      let cachedConfig = storedConfig;
+      getConfigMock.mockImplementation(() => cachedConfig);
+      refreshAnalyticsConfigMock.mockImplementation(() => {
+        cachedConfig = storedConfig;
+        return Promise.resolve(cachedConfig);
+      });
+      fetchMock.mockResolvedValue({
+        ok: true,
+        clone: () => ({ text: () => Promise.resolve('') })
+      });
+
+      const { clearQueuedUsageAnalyticsEventsIfConsentRevoked, trackUsageEvent } =
+        await import('../../../src/background/services/analyticsEvents');
+      await trackUsageEvent('support_like_clicked', { variant: 'first' });
+      await trackUsageEvent('support_dislike_clicked');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const revokedConfig = createAnalyticsConfig({
+        userConsent: { analytics: false, errorReporting: false },
+        reportingInterval: 60000,
+        batchSize: 1
+      });
+      storedConfig = revokedConfig;
+      clearQueuedUsageAnalyticsEventsIfConsentRevoked(revokedConfig);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      storedConfig = createAnalyticsConfig({
+        reportingInterval: 60000,
+        batchSize: 1
+      });
+      vi.setSystemTime(201000);
+      await trackUsageEvent('support_github_feedback_clicked');
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [, requestInit] = fetchMock.mock.calls[1] ?? [];
+      expect(String(requestInit?.body)).toContain('"name":"support_github_feedback_clicked"');
+      expect(String(requestInit?.body)).not.toContain('"name":"support_dislike_clicked"');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('warns when initialization or request handling fails and can retry afterwards', async () => {

--- a/tests/unit/background/bootstrap.test.ts
+++ b/tests/unit/background/bootstrap.test.ts
@@ -6,6 +6,19 @@ const TOKENS = vi.hoisted(() => ({
   globalStateManager: Symbol('globalStateManager'),
   usageStatsStore: Symbol('usageStatsStore')
 }));
+type AnalyticsWatchConfig = {
+  enabled: boolean;
+  userConsent?: {
+    analytics?: boolean;
+    errorReporting?: boolean;
+  };
+};
+const analyticsConfigWatchState = vi.hoisted(
+  (): {
+    onRefresh?: (config: AnalyticsWatchConfig) => void;
+  } => ({})
+);
+const stopWatchingAnalyticsConfigMock = vi.hoisted(() => vi.fn());
 const registryState = vi.hoisted(() => ({ tokens: new Set<symbol>() }));
 const registryMock = vi.hoisted(() => ({
   register: vi.fn((token: symbol) => {
@@ -23,6 +36,13 @@ const createErrorHandlerMock = vi.hoisted(() => vi.fn(() => ({ dispose: vi.fn() 
 const createGlobalStateManagerMock = vi.hoisted(() => vi.fn(() => ({ dispose: vi.fn() })));
 const configureGlobalStateManagerStorageMock = vi.hoisted(() => vi.fn());
 const configureAnalyticsConfigManagerMock = vi.hoisted(() => vi.fn());
+const watchAnalyticsConfigStorageMock = vi.hoisted(() =>
+  vi.fn((onRefresh: (config: AnalyticsWatchConfig) => void) => {
+    analyticsConfigWatchState.onRefresh = onRefresh;
+    return stopWatchingAnalyticsConfigMock;
+  })
+);
+const clearQueuedUsageAnalyticsEventsIfConsentRevokedMock = vi.hoisted(() => vi.fn());
 const initializeErrorAnalyticsMock = vi.hoisted(() => vi.fn(async () => undefined));
 const configureI18nStorageMock = vi.hoisted(() => vi.fn());
 const configureUsageStatsStorageMock = vi.hoisted(() => vi.fn());
@@ -43,10 +63,15 @@ vi.mock('../../../src/shared/errors/errorHandler', () => ({
   createErrorHandler: createErrorHandlerMock
 }));
 vi.mock('../../../src/shared/errors/analytics/analyticsConfig', () => ({
-  configureAnalyticsConfigManager: configureAnalyticsConfigManagerMock
+  configureAnalyticsConfigManager: configureAnalyticsConfigManagerMock,
+  watchAnalyticsConfigStorage: watchAnalyticsConfigStorageMock
 }));
 vi.mock('../../../src/shared/errors/analytics', () => ({
   initializeErrorAnalytics: initializeErrorAnalyticsMock
+}));
+vi.mock('../../../src/background/services/analyticsEvents', () => ({
+  clearQueuedUsageAnalyticsEventsIfConsentRevoked:
+    clearQueuedUsageAnalyticsEventsIfConsentRevokedMock
 }));
 vi.mock('../../../src/shared/errors/globalErrorBoundary', () => ({
   registerGlobalErrorBoundary: registerGlobalErrorBoundaryMock
@@ -68,6 +93,7 @@ describe('background/bootstrap', () => {
     vi.resetModules();
     vi.clearAllMocks();
     registryState.tokens.clear();
+    analyticsConfigWatchState.onRefresh = undefined;
   });
 
   it('bootstraps background dependencies and reports initialized state', async () => {
@@ -78,6 +104,7 @@ describe('background/bootstrap', () => {
     expect(configureAnalyticsConfigManagerMock).toHaveBeenCalledWith(storageMock);
     expect(configureI18nStorageMock).toHaveBeenCalledWith(storageMock.sync);
     expect(configureUsageStatsStorageMock).toHaveBeenCalledWith(storageMock);
+    expect(watchAnalyticsConfigStorageMock).toHaveBeenCalledTimes(1);
     expect(registryMock.register).toHaveBeenCalledWith(TOKENS.errorHandler, expect.any(Function));
     expect(registerGlobalErrorBoundaryMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -97,6 +124,22 @@ describe('background/bootstrap', () => {
     expect(mod.isBackgroundDependenciesInitialized()).toBe(true);
   });
 
+  it('clears queued usage analytics when analytics storage changes revoke consent', async () => {
+    const mod = await import('../../../src/background/bootstrap');
+    mod.bootstrapBackgroundDependencies(storageMock);
+
+    expect(analyticsConfigWatchState.onRefresh).toBeTypeOf('function');
+    analyticsConfigWatchState.onRefresh?.({
+      enabled: false,
+      userConsent: { analytics: false, errorReporting: false }
+    });
+
+    expect(clearQueuedUsageAnalyticsEventsIfConsentRevokedMock).toHaveBeenCalledWith({
+      enabled: false,
+      userConsent: { analytics: false, errorReporting: false }
+    });
+  });
+
   it('ensures once, resets, and re-registers background dependencies', async () => {
     const mod = await import('../../../src/background/bootstrap');
     mod.ensureBackgroundDependencies(storageMock);
@@ -112,6 +155,7 @@ describe('background/bootstrap', () => {
     expect(registryMock.reset).toHaveBeenCalledTimes(1);
     expect(mod.isBackgroundDependenciesInitialized()).toBe(true);
     expect(initializeErrorAnalyticsMock).toHaveBeenCalledTimes(2);
+    expect(watchAnalyticsConfigStorageMock).toHaveBeenCalledTimes(2);
   });
 
   it('cleans up tokens and swallows disposal failures', async () => {
@@ -124,6 +168,7 @@ describe('background/bootstrap', () => {
       throw new Error('dispose failed');
     });
     mod.cleanupBackgroundDependencies();
+    expect(stopWatchingAnalyticsConfigMock).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       '[Background] Error during dependency cleanup:',
       expect.any(Error)

--- a/tests/unit/shared/errors/analytics/googleAnalyticsReporter.test.ts
+++ b/tests/unit/shared/errors/analytics/googleAnalyticsReporter.test.ts
@@ -25,9 +25,13 @@ vi.mock('../../../../../src/shared/di', () => ({ getService: getServiceMock }));
 vi.mock('../../../../../src/shared/errors/analytics/dataSanitizer', () => ({
   sanitizeErrorForAnalytics: sanitizeErrorForAnalyticsMock
 }));
-vi.mock('../../../../../src/shared/analytics', () => ({
-  sendAnalyticsTransportEvent: sendAnalyticsTransportEventMock
-}));
+vi.mock('../../../../../src/shared/analytics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../src/shared/analytics')>();
+  return {
+    ...actual,
+    sendAnalyticsTransportEvent: sendAnalyticsTransportEventMock
+  };
+});
 
 describe('GoogleAnalyticsReporter', () => {
   const fetchMock = vi.fn();
@@ -143,6 +147,68 @@ describe('GoogleAnalyticsReporter', () => {
     reporter.updateConfig({ enabled: false });
     expect(reporter.isEnabled()).toBe(false);
     reporter.renewSession();
+  });
+
+  it('queues repeated extension errors according to reporting interval and batch size', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(300000);
+      const { GoogleAnalyticsReporter } =
+        await import('../../../../../src/shared/errors/analytics/googleAnalyticsReporter');
+      const reporter = new GoogleAnalyticsReporter({
+        enabled: true,
+        measurementId: 'G-123',
+        transportMode: 'proxy',
+        proxyEndpoint: 'https://analytics.example.test/ga4',
+        reportingInterval: 60000,
+        batchSize: 1,
+        clientId: 'client',
+        sessionId: 'session'
+      });
+
+      await reporter.report({
+        code: 'REST_NETWORK_TIMEOUT',
+        domain: 'background',
+        severity: ErrorSeverity.CRITICAL,
+        recoverable: true,
+        message: 'first',
+        timestamp: Date.now()
+      });
+      await reporter.report({
+        code: 'REST_NETWORK_UNAVAILABLE',
+        domain: 'background',
+        severity: ErrorSeverity.WARNING,
+        recoverable: true,
+        message: 'second',
+        timestamp: Date.now()
+      });
+
+      expect(sendAnalyticsTransportEventMock).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(361000);
+      await reporter.report({
+        code: 'REST_REQUEST_ABORTED',
+        domain: 'background',
+        severity: ErrorSeverity.INFO,
+        recoverable: true,
+        message: 'third',
+        timestamp: Date.now()
+      });
+
+      expect(sendAnalyticsTransportEventMock).toHaveBeenCalledTimes(2);
+      expect(sendAnalyticsTransportEventMock.mock.calls[1]?.[1]).toEqual(
+        expect.objectContaining({
+          error_code: 'REST_NETWORK_UNAVAILABLE'
+        })
+      );
+      expect(sendAnalyticsTransportEventMock.mock.calls[1]?.[1]).not.toEqual(
+        expect.objectContaining({
+          error_code: 'REST_REQUEST_ABORTED'
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('swallows transport failures and falls back when manifest lookup fails', async () => {


### PR DESCRIPTION
## Summary
- Route production usage GA events and `extension_error` reporting through the shared analytics queue so `reportingInterval` and `batchSize` are effective.
- Stop failed analytics initialization from continuing with stale state, and clear queued usage events when analytics consent/config is revoked or cleared.
- Add regression coverage for queue interval/batch behavior, consent revoke/restore clearing, bootstrap storage watcher cleanup, and GA error reporter queueing.

## Verification
- `git fetch origin main` -> branch merge-base matches current `origin/main`; branch is ahead by 1 commit.
- `npm run typecheck`
- `npm run lint` -> 0 errors / 125 existing warnings
- `npm run test:unit` -> 304 files / 1814 tests passed
- `PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run quality`
- `PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run verify:preflight`
- `git diff --check`

## Remaining Owner-Assisted Evidence
- Real GA4/proxy/DebugView/dashboard validation still requires the owner production property/proxy environment and is not exercised by this local code branch.
