### PR TITLE
ci: parallelize workflow gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,19 @@ on:
       - develop
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write
 
 jobs:
-  test:
+  static-gates:
+    name: Static gates
     runs-on: ubuntu-latest
+    timeout-minutes: 12
 
     steps:
       - name: Checkout repository
@@ -27,15 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Typecheck app
-        run: npm run typecheck:app
-
-      - name: Typecheck tests
-        run: npm run typecheck:tests
-
-      - name: Typecheck strict baseline
-        run: npm run typecheck:strict
 
       - name: Verify generated i18n catalog artifacts are up to date
         run: npm run i18n:catalog:check
@@ -73,6 +70,34 @@ jobs:
 
       - name: Enforce lint warning guard
         run: npm run lint:warnings-guard
+
+      - name: Verify generated Chrome locales are up to date
+        run: |
+          npm run i18n:generate
+          git diff --exit-code -- public/_locales
+
+      - name: Verify generated browser manifests are up to date
+        run: |
+          npm run manifest:generate
+          git diff --exit-code -- public/manifest.json public/manifest.firefox.json
+
+  coverage:
+    name: Unit coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run unit tests with coverage thresholds
         run: npm run test:coverage
@@ -131,18 +156,100 @@ jobs:
               });
             }
 
+  visual:
+    name: Visual regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Run i18n visual regression tests
+        run: npm run visual:test
+
+      - name: Upload visual reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-reports
+          path: |
+            build/reports/
+            tests/visual/__output__/
+          if-no-files-found: ignore
+
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright dependencies
+        run: npx playwright install --with-deps chromium
+
+      - name: Run end-to-end tests
+        run: |
+          npm run test:e2e
+          npm run test:e2e:browser
+          npm run test:e2e:browser:reader-panel
+          npm run test:e2e:browser:smoke
+
+      - name: Upload e2e reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-reports
+          path: |
+            build/reports/
+            tests/visual/__output__/
+            build/reports/playwright/
+          if-no-files-found: ignore
+
+  package:
+    name: Package extension
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    needs: [static-gates, coverage, visual, e2e]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Build production bundle
-        run: npm run build
-
-      - name: Verify generated Chrome locales are up to date
-        run: |
-          npm run i18n:generate
-          git diff --exit-code -- public/_locales
-
-      - name: Verify generated browser manifests are up to date
-        run: |
-          npm run manifest:generate
-          git diff --exit-code -- public/manifest.json public/manifest.firefox.json
+        run: npm run build:fast
 
       - name: Validate text budgets
         run: npm run validate:i18n:budgets
@@ -153,32 +260,8 @@ jobs:
       - name: Generate layout summary
         run: npm run report:layout
 
-      - name: Install Playwright dependencies
-        run: npx playwright install --with-deps chromium
-
-      - name: Run i18n visual regression tests
-        run: npm run visual:test
-
-      - name: Run end-to-end tests
-        run: |
-          npm run test:e2e
-          npm run test:e2e:browser
-          npm run test:e2e:browser:reader-panel
-          npm run test:e2e:browser:smoke
-
       - name: Generate release summary
         run: npm run report:release-summary
-
-      - name: Upload i18n reports
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: i18n-reports
-          path: |
-            build/reports/
-            tests/visual/__output__/
-            build/reports/playwright/
-          if-no-files-found: ignore
 
       - name: Upload release summary
         uses: actions/upload-artifact@v4
@@ -190,6 +273,4 @@ jobs:
           if-no-files-found: error
 
       - name: Package extension artifacts
-        run: |
-          npm run build:fast
-          npm run package:ci
+        run: npm run package:ci

--- a/docs/engineering-entrypoints.md
+++ b/docs/engineering-entrypoints.md
@@ -1,6 +1,6 @@
 # 工程命令与入口
 
-最后更新：2026-06-11
+最后更新：2026-06-12
 
 ## 推荐运行环境
 
@@ -35,11 +35,13 @@
   - 显式包含 `i18n:catalog:check`
   - 串行继续执行 `lint -- --quiet`、`build:dev`、`audit:*` 报告
 - `.github/workflows/ci.yml`
-  - 显式执行同一组三项 typecheck，不再依赖隐式覆盖
-  - `Verify generated i18n catalog artifacts are up to date` 显式运行 `npm run i18n:catalog:check`
+  - 采用并行 job 拓扑：`static-gates`、`coverage`、`visual`、`e2e` 并行执行，`package` 通过 `needs: [static-gates, coverage, visual, e2e]` 汇总后再打包
+  - 使用 workflow-level `concurrency`，同一 PR / ref 的新 run 会取消旧 run
+  - `static-gates` 显式运行 `npm run i18n:catalog:check` 与 `npm run verify:preflight`；三项 typecheck 仍由 `verify:preflight` 显式覆盖
   - `Verify preflight baseline` 后显式运行 `build:fast` 与 `audit:release-surface:report`
   - `Locale source alignment audit report` 是 hard gate，不再 `continue-on-error`
   - `Enforce hardcoded config guard` 显式运行 `npm run lint:hardcoded`
+  - `package` job 只在前置门禁通过后使用 `npm run build:fast`，避免在 CI 后段通过 `npm run build` 重复触发完整 `quality`
 - 2026-05-22 final exit gate 真值：在 Node `v20.20.2` / npm `10.8.2` 下，`quality`、`verify:preflight`、`test:unit`、`clean`、`build:dev`、`audit:build:report`、`audit:performance:report`、`verify:stitch-secondary`、`visual:test`、browser smoke、reader-panel、local-vault 均已通过；`build/dist/content/runtime.js` raw `54,554` bytes，低于当时 `57,600` stop gate
 - 2026-05-24 M2.5 budget ratchet 真值：M2.1-M2.4 合入后，`audit:build:report` 的 `content/runtime.js` raw stop gate 收紧为 `56,320` bytes；chunk count 收紧为 `<= 112`；hotspot line budgets 以 `docs/performance-baseline.md` 为准
 - 2026-06-07 video legacy recovery 真值：视频/阅读 draft 自动恢复入口改为 lazy `sessionDraftAutoRestore-*` chunk 后，`audit:build:report` 的 `content/runtime.js` raw stop gate 同步为 `57,344` bytes；chunk count 继续守住 `<= 112`；完整 build/hotspot 真值以 `docs/performance-baseline.md` 为准

--- a/docs/source-of-truth-index.md
+++ b/docs/source-of-truth-index.md
@@ -1,6 +1,6 @@
 # Source of Truth 索引
 
-最后更新：2026-06-11
+最后更新：2026-06-12
 
 ## 正式入口
 
@@ -28,6 +28,7 @@
 - Local Vault / offscreen / manifest / release 风险的当前真值来自 2026-05-18 stabilization ledger、2026-05-19 gap closure ledger、集成提交和 `audit:local-vault-release:report`
 - Release surface 当前真值：production builds/package outputs 不包含 dev/test harness HTML/JS；dev builds 保留 harness 页面；`audit:release-surface:report` 校验 manifest 文件引用与 forbidden harness package members，并已接入 `quality` 与 CI release-surface 步骤；Chrome ZIP 与 Firefox XPI package 脚本会先解包最终产物，再对解包目录执行同一 release-surface 审计
 - Quality gate 当前真值：`quality` 包含 i18n catalog drift check、locale source alignment、hardcoded config 守卫、type/lint ratchet、release surface 与 non-production source hard gate；CI i18n catalog drift check、locale source alignment 与 hardcoded config guard 均为 hard gate；`verify:preflight` 同样显式包含 `i18n:catalog:check`；`lint:options-css` 对当前 `src/options/stitch/styles/**` 解析出非空 `selector-class-pattern` 规则
+- CI 拓扑当前真值：`.github/workflows/ci.yml` 使用 workflow-level `concurrency` 取消同一 PR / ref 的旧 run；`static-gates`、`coverage`、`visual`、`e2e` 并行执行，`package` 通过 `needs: [static-gates, coverage, visual, e2e]` 汇总后运行；`package` job 只在前置门禁通过后使用 `build:fast`，不得改回会重复触发完整 `quality` 的 `npm run build`
 - i18n 语言范围当前真值：产品决策标签为 `release-13-languages`；release-supported human UI locales 为 `en`、`zh-CN`、`ja`、`de`、`fr`、`es-ES`、`es-419`、`it`、`ko`、`pt-BR`、`ru`、`zh-TW`；README、runtime config、locale loaders、`src/i18n/catalog/messages/<lang>/{runtime,static,schema}.json`、`src/i18n/generated/locales/*.generated.ts` 与 WebExtension `_locales` 必须与该范围一致；当前 catalog-owned checked-in static source 为 `public/_locales/**`
 - `qps-ploc` 当前分类为 `dev-test-only` pseudo-locale：仅用于开发/测试伪本地化；production runtime locale registry、production build output、Chrome ZIP 与 Firefox XPI 均不得包含 `qps-ploc` loader/chunk 或 `_locales/qps-ploc/messages.json`
 - root `_locales/**` 已删除，不再作为 retained compatibility duplicate 保留；production build/package/release surface owner 为 `public/_locales/**` -> `build/dist/_locales/**` -> final Chrome ZIP / Firefox XPI

--- a/tests/unit/tools/ciWorkflow.test.ts
+++ b/tests/unit/tools/ciWorkflow.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function readCiWorkflow(): string {
+  return readFileSync(resolve('.github/workflows/ci.yml'), 'utf8');
+}
+
+describe('CI workflow wiring', () => {
+  it('cancels superseded runs for the same workflow ref or PR', () => {
+    const workflow = readCiWorkflow();
+
+    expect(workflow).toContain('concurrency:');
+    expect(workflow).toContain(
+      'group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}'
+    );
+    expect(workflow).toContain('cancel-in-progress: true');
+  });
+
+  it('splits independent checks into parallel jobs before packaging', () => {
+    const workflow = readCiWorkflow();
+
+    expect(workflow).toContain('static-gates:');
+    expect(workflow).toContain('coverage:');
+    expect(workflow).toContain('visual:');
+    expect(workflow).toContain('e2e:');
+    expect(workflow).toContain('package:');
+    expect(workflow).toContain('needs: [static-gates, coverage, visual, e2e]');
+  });
+
+  it('uses fast production builds after static gates have already run', () => {
+    const workflow = readCiWorkflow();
+
+    expect(workflow).not.toMatch(/run:\s*npm run build\s*(?:\n|$)/);
+    expect(workflow).toContain('run: npm run build:fast');
+    expect(workflow).toContain('npm run package:ci');
+  });
+});


### PR DESCRIPTION
## Summary
- Split the previous serial CI workflow into parallel `static-gates`, `coverage`, `visual`, and `e2e` jobs, followed by a gated `package` job.
- Add workflow-level concurrency so superseded runs for the same PR/ref are canceled.
- Use `build:fast` in the package job after upstream static gates have passed, avoiding repeated full `quality` work late in CI.
- Add a workflow wiring unit test and update engineering/source-of-truth docs.

## Test Plan
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npx vitest run --config vitest.unit.config.ts tests/unit/tools/ciWorkflow.test.ts tests/unit/tools/i18nGateWiring.test.ts`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:coverage`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:e2e`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:e2e:browser`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:e2e:browser:reader-panel`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:e2e:browser:smoke`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run visual:test`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run quality`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run verify:preflight`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run build:firefox`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run build:fast`
- `PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run package:ci`
