### PR TITLE
Fix reader draft coverage flake

### DIFF
--- a/tests/unit/content/sessionDrafts/readerSessionDrafts.test.ts
+++ b/tests/unit/content/sessionDrafts/readerSessionDrafts.test.ts
@@ -32,7 +32,7 @@ function createHighlightRecord(
 describe('readerSessionDrafts', () => {
   it('builds and loads a persisted reader draft with destination and comment drafts', async () => {
     const repository = createSessionDraftRepository(createMemoryStorageArea());
-    const now = 1_780_617_600_000;
+    const now = Date.now();
     const envelope = buildReaderSessionDraftEnvelope({
       draftId: 'reader-draft-1',
       createdAt: now - 10,


### PR DESCRIPTION
## Summary
- keep the reader session draft persistence fixture inside the repository TTL window
- fixes the main CI unit coverage failure that appeared after the optimized workflow merged

## Verification
- PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npx vitest run --config vitest.unit.config.ts tests/unit/content/sessionDrafts/readerSessionDrafts.test.ts
- PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:coverage
- PATH=/Users/mac/.nvm/versions/node/v20.20.2/bin:$PATH npx lint-staged
- pre-commit hook via git commit