### PR TITLE
Fix downloads fallback for full-page clips

### DIFF
--- a/src/background/application/clipProcessor.ts
+++ b/src/background/application/clipProcessor.ts
@@ -1,10 +1,7 @@
 import { getOptions } from '../store';
 import { RUNTIME_FALLBACK_MESSAGES } from '../../i18n/catalog/runtimeFallbackMessages';
-import { resolvePath } from '../pathResolver';
-import { selectVaultForClip } from '../services/vaultRouterService';
 import { classifyClip } from '../services/classificationService';
 import type { ClassificationResult } from '../services/classificationService';
-import { createVaultWriteSession } from '../services/obsidianWriter';
 import type {
   LocalVaultFallbackReason,
   LocalVaultPermissionPromptRequest,
@@ -24,19 +21,14 @@ import {
   type StorageTarget,
   type UsageEventParamMap
 } from '../../shared/analytics';
-import {
-  parseExportDestinationMetadata,
-  toDownloadsFilename
-} from '../../shared/exportDestination';
+import { resolveClipRoute, type ResolvedClipRoute } from './clipRouteResolver';
 import { isAppError, normalizeToAppError } from '../../shared/errors';
 import type { AppError } from '../../shared/errors';
 import { getService } from '../../shared/di';
 import { TOKENS } from '../../shared/di/tokens';
 import type { UserVisibleMessageDescriptor } from '../../shared/i18n/userVisibleMessageDescriptor';
 import type { PlatformServices } from '../../platform/types';
-import type { RestOptions } from '../../shared/types/options';
 import { serializedAttachmentContentToBlob } from '../../shared/attachments/clipAttachmentBinary';
-import { prepareVideoClipAttachments } from './videoScreenshotAttachmentPlanner';
 
 export interface ClipProcessingResult {
   filePath: string;
@@ -201,69 +193,20 @@ export async function processClipPayload(
     const classification = await completeStage('classify', () => classifyClip(options, payload));
 
     const routed = await completeStage('route', async () => {
-      const filePath = resolvePath(
-        options.templates,
-        payload,
-        classification,
-        options.domainMappings
-      );
-      const exportDestination = parseExportDestinationMetadata(payload.meta?.exportDestination);
-
-      const createDownloadsRoute = () => {
-        storageTarget = 'downloads';
-        const filename = toDownloadsFilename(filePath);
-        return {
-          destination: 'downloads' as const,
-          filePath: filename,
-          restVault: '',
-          prepared: prepareVideoClipAttachments({
-            payload,
-            notePath: filename,
-            destination: 'downloads',
-            ...(options.video?.screenshotAttachment
-              ? { screenshotAttachmentOptions: options.video.screenshotAttachment }
-              : {})
-          })
-        };
-      };
-
-      if (exportDestination?.kind === 'downloads') {
-        return createDownloadsRoute();
-      }
-
       hooks.onProgress?.({
         value: 56,
         message: createClipProgressMessage('supportProgressSelectingVault')
       });
-      const { vault, restConfig } = selectVaultForClip(options, payload);
-      if (!isWritableVaultRestConfig(restConfig)) {
-        return createDownloadsRoute();
-      }
-
-      const prepared = prepareVideoClipAttachments({
+      return resolveClipRoute({
+        options,
         payload,
-        notePath: filePath,
-        destination: 'vault',
-        ...(options.video?.screenshotAttachment
-          ? { screenshotAttachmentOptions: options.video.screenshotAttachment }
-          : {})
-      });
-      const writeSession = await createVaultWriteSession(restConfig, {
+        classification,
         ...(hooks.requestLocalVaultPermission
           ? { requestLocalVaultPermission: hooks.requestLocalVaultPermission }
           : {})
       });
-      storageTarget = toAnalyticsStorageTarget(writeSession.target.storageTarget);
-
-      return {
-        destination: 'vault' as const,
-        filePath,
-        vault,
-        restConfig,
-        prepared,
-        writeSession
-      };
     });
+    storageTarget = toRouteStorageTarget(routed);
 
     if (routed.destination === 'downloads') {
       hooks.onProgress?.({
@@ -426,12 +369,6 @@ export async function processClipPayload(
   }
 }
 
-function isWritableVaultRestConfig(restConfig: RestOptions): boolean {
-  return Boolean(
-    restConfig.localFolderId?.trim() || (restConfig.vault?.trim() && restConfig.apiKey?.trim())
-  );
-}
-
 function resolveBackgroundOperationId(payload: ClipPayload): string {
   const meta = payload.meta;
   const candidate =
@@ -481,6 +418,12 @@ function toAnalyticsStorageTarget(
     return value;
   }
   return value === 'local-folder' ? 'local_folder' : 'rest_api';
+}
+
+function toRouteStorageTarget(route: ResolvedClipRoute): StorageTarget {
+  return route.destination === 'downloads'
+    ? 'downloads'
+    : toAnalyticsStorageTarget(route.writeSession.target.storageTarget);
 }
 
 function resolveFailureCategory(

--- a/src/background/application/clipProcessor.ts
+++ b/src/background/application/clipProcessor.ts
@@ -34,6 +34,7 @@ import { getService } from '../../shared/di';
 import { TOKENS } from '../../shared/di/tokens';
 import type { UserVisibleMessageDescriptor } from '../../shared/i18n/userVisibleMessageDescriptor';
 import type { PlatformServices } from '../../platform/types';
+import type { RestOptions } from '../../shared/types/options';
 import { serializedAttachmentContentToBlob } from '../../shared/attachments/clipAttachmentBinary';
 import { prepareVideoClipAttachments } from './videoScreenshotAttachmentPlanner';
 
@@ -208,7 +209,7 @@ export async function processClipPayload(
       );
       const exportDestination = parseExportDestinationMetadata(payload.meta?.exportDestination);
 
-      if (exportDestination?.kind === 'downloads') {
+      const createDownloadsRoute = () => {
         storageTarget = 'downloads';
         const filename = toDownloadsFilename(filePath);
         return {
@@ -224,6 +225,10 @@ export async function processClipPayload(
               : {})
           })
         };
+      };
+
+      if (exportDestination?.kind === 'downloads') {
+        return createDownloadsRoute();
       }
 
       hooks.onProgress?.({
@@ -231,6 +236,10 @@ export async function processClipPayload(
         message: createClipProgressMessage('supportProgressSelectingVault')
       });
       const { vault, restConfig } = selectVaultForClip(options, payload);
+      if (!isWritableVaultRestConfig(restConfig)) {
+        return createDownloadsRoute();
+      }
+
       const prepared = prepareVideoClipAttachments({
         payload,
         notePath: filePath,
@@ -415,6 +424,12 @@ export async function processClipPayload(
     });
     throw withClipProcessingFailureCategory(error, failureCategory);
   }
+}
+
+function isWritableVaultRestConfig(restConfig: RestOptions): boolean {
+  return Boolean(
+    restConfig.localFolderId?.trim() || (restConfig.vault?.trim() && restConfig.apiKey?.trim())
+  );
 }
 
 function resolveBackgroundOperationId(payload: ClipPayload): string {

--- a/src/background/application/clipRouteResolver.ts
+++ b/src/background/application/clipRouteResolver.ts
@@ -1,0 +1,114 @@
+import { resolvePath } from '../pathResolver';
+import { createVaultWriteSession, type VaultWriteSession } from '../services/obsidianWriter';
+import type {
+  LocalVaultPermissionPromptRequest,
+  LocalVaultPermissionPromptResult
+} from '../services/obsidianWriter';
+import { selectVaultForClip } from '../services/vaultRouterService';
+import type { ClassificationResult } from '../services/classificationService';
+import type { Options } from '../store';
+import {
+  parseExportDestinationMetadata,
+  toDownloadsFilename
+} from '../../shared/exportDestination';
+import type { ClipResultMessage, VaultConfig } from '../../shared/types';
+import type { RestOptions } from '../../shared/types/options';
+import {
+  prepareVideoClipAttachments,
+  type PreparedClipAttachments
+} from './videoScreenshotAttachmentPlanner';
+
+type ClipPayload = NonNullable<ClipResultMessage['payload']>;
+
+export type ResolvedClipRoute =
+  | {
+      destination: 'downloads';
+      filePath: string;
+      restVault: '';
+      prepared: PreparedClipAttachments;
+    }
+  | {
+      destination: 'vault';
+      filePath: string;
+      vault: VaultConfig | null;
+      restConfig: Options['rest'];
+      prepared: PreparedClipAttachments;
+      writeSession: VaultWriteSession;
+    };
+
+export interface ResolveClipRouteParams {
+  options: Options;
+  payload: ClipPayload;
+  classification: ClassificationResult;
+  requestLocalVaultPermission?: (
+    request: LocalVaultPermissionPromptRequest
+  ) => Promise<LocalVaultPermissionPromptResult>;
+}
+
+export async function resolveClipRoute({
+  options,
+  payload,
+  classification,
+  requestLocalVaultPermission
+}: ResolveClipRouteParams): Promise<ResolvedClipRoute> {
+  const filePath = resolvePath(options.templates, payload, classification, options.domainMappings);
+  const exportDestination = parseExportDestinationMetadata(payload.meta?.exportDestination);
+  const createDownloadsRoute = () => createDownloadsClipRoute(options, payload, filePath);
+
+  if (exportDestination?.kind === 'downloads') {
+    return createDownloadsRoute();
+  }
+
+  const { vault, restConfig } = selectVaultForClip(options, payload);
+  if (!isWritableVaultRestConfig(restConfig)) {
+    return createDownloadsRoute();
+  }
+
+  const prepared = prepareVideoClipAttachments({
+    payload,
+    notePath: filePath,
+    destination: 'vault',
+    ...(options.video?.screenshotAttachment
+      ? { screenshotAttachmentOptions: options.video.screenshotAttachment }
+      : {})
+  });
+  const writeSession = await createVaultWriteSession(restConfig, {
+    ...(requestLocalVaultPermission ? { requestLocalVaultPermission } : {})
+  });
+
+  return {
+    destination: 'vault',
+    filePath,
+    vault,
+    restConfig,
+    prepared,
+    writeSession
+  };
+}
+
+function createDownloadsClipRoute(
+  options: Options,
+  payload: ClipPayload,
+  vaultFilePath: string
+): Extract<ResolvedClipRoute, { destination: 'downloads' }> {
+  const filePath = toDownloadsFilename(vaultFilePath);
+  return {
+    destination: 'downloads',
+    filePath,
+    restVault: '',
+    prepared: prepareVideoClipAttachments({
+      payload,
+      notePath: filePath,
+      destination: 'downloads',
+      ...(options.video?.screenshotAttachment
+        ? { screenshotAttachmentOptions: options.video.screenshotAttachment }
+        : {})
+    })
+  };
+}
+
+function isWritableVaultRestConfig(restConfig: RestOptions): boolean {
+  return Boolean(
+    restConfig.localFolderId?.trim() || (restConfig.vault?.trim() && restConfig.apiKey?.trim())
+  );
+}

--- a/src/options/stitch/styles/runtime/session-panel.css
+++ b/src/options/stitch/styles/runtime/session-panel.css
@@ -1,4 +1,3 @@
-
 .session-panel-rail {
   position: relative;
   height: auto;
@@ -95,14 +94,39 @@
 }
 
 .resource-modal--session.is-collapsed .surface-window-header {
-  grid-template-columns: auto minmax(0, auto);
+  grid-template-columns: minmax(0, max-content);
   justify-content: center;
   align-items: center;
+  justify-items: center;
 }
 
 .resource-modal--session.is-collapsed .surface-window-brand {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  gap: var(--session-header-column-gap);
+  min-width: 0;
+  max-width: calc(100vw - var(--surface-side-gap) - (var(--session-header-padding-x) * 2));
+}
+
+.resource-modal--session.is-collapsed .surface-window-brand > .surface-heading-copy {
+  align-items: center;
+  min-width: 0;
+  transform: none;
+}
+
+.resource-modal--session.is-collapsed .surface-window-icon {
+  flex: 0 0 var(--session-header-icon-size);
+  transform: none;
+}
+
+.resource-modal--session.is-collapsed .surface-window-title {
+  left: auto;
+  top: auto;
+  max-width: 100%;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
 }
 
 .resource-modal--session.is-collapsed .surface-window-subtitle,

--- a/src/shared/exportDestination.ts
+++ b/src/shared/exportDestination.ts
@@ -191,7 +191,10 @@ export function hasConfiguredVaultTarget(
   options: OptionsState,
   vaults = getConfiguredVaults(options)
 ): boolean {
-  return vaults.some((vault) => Boolean(vault.apiKey?.trim())) || isRestConfigured(options);
+  return (
+    vaults.some((vault) => Boolean(vault.localFolderId?.trim() || vault.apiKey?.trim())) ||
+    isRestConfigured(options)
+  );
 }
 
 export function selectVaultForPreview(

--- a/tests/unit/background/clipProcessor.test.ts
+++ b/tests/unit/background/clipProcessor.test.ts
@@ -23,7 +23,7 @@ const getServiceMock = vi.hoisted(() =>
   }))
 );
 
-const templateOptions = { article: '', fragment: '', reading: '', ai: '' } as const;
+const templateOptions = { article: '', video: '', fragment: '', reading: '', ai: '' } as const;
 
 vi.mock('../../../src/background/store', () => ({
   getOptions: getOptionsMock
@@ -227,14 +227,14 @@ describe('clipProcessor', () => {
     });
     selectVaultMock.mockReturnValue({
       vault: null,
-      restConfig: { baseUrl: 'https://default', vault: 'Vault', apiKey: '' },
+      restConfig: { baseUrl: 'https://default', vault: 'Vault', apiKey: 'key' },
       context: {}
     });
     const classificationResult = {
       type: 'article',
       topics: [],
       tags: [],
-      status: 'success' as const
+      status: 'success'
     };
     classifyClipMock.mockResolvedValue(classificationResult);
     resolvePathMock.mockReturnValue('Articles/foo.md');
@@ -532,7 +532,7 @@ describe('clipProcessor', () => {
       type: 'article',
       topics: [],
       tags: [],
-      status: 'success' as const
+      status: 'success'
     };
     classifyClipMock.mockResolvedValue(classificationResult);
     resolvePathMock.mockReturnValue('Articles/downloaded-note.md');
@@ -559,6 +559,51 @@ describe('clipProcessor', () => {
     });
     expect(result).toEqual({
       filePath: 'downloaded-note.md',
+      restVault: '',
+      destination: 'downloads',
+      storageTarget: 'downloads',
+      classification: classificationResult
+    });
+  });
+
+  it('falls back to downloads for article clips when no writable vault target is configured', async () => {
+    const restConfig = { baseUrl: 'https://default', vault: '', apiKey: '' };
+    getOptionsMock.mockResolvedValue({
+      templates: templateOptions,
+      domainMappings: {},
+      rest: restConfig,
+      vaultRouter: { vaults: [] }
+    });
+    selectVaultMock.mockReturnValue({
+      vault: null,
+      restConfig,
+      context: {}
+    });
+    const classificationResult = {
+      type: 'article',
+      topics: [],
+      tags: [],
+      status: 'success' as const
+    };
+    classifyClipMock.mockResolvedValue(classificationResult);
+    resolvePathMock.mockReturnValue('Articles/unconfigured-note.md');
+    downloadMock.mockResolvedValue(12);
+    recordUsageMock.mockResolvedValue(undefined);
+
+    const { processClipPayload } =
+      await import('../../../src/background/application/clipProcessor');
+    const result = await processClipPayload(createPayload());
+
+    expect(selectVaultMock).toHaveBeenCalled();
+    expect(createWriteSessionMock).not.toHaveBeenCalled();
+    expect(writeMarkdownMock).not.toHaveBeenCalled();
+    expect(downloadMock).toHaveBeenCalledWith({
+      filename: 'unconfigured-note.md',
+      content: '# note',
+      mimeType: 'text/markdown;charset=utf-8'
+    });
+    expect(result).toEqual({
+      filePath: 'unconfigured-note.md',
       restVault: '',
       destination: 'downloads',
       storageTarget: 'downloads',
@@ -970,7 +1015,7 @@ describe('clipProcessor', () => {
     });
     selectVaultMock.mockReturnValue({
       vault: null,
-      restConfig: { baseUrl: 'https://default', vault: 'Vault', apiKey: '' },
+      restConfig: { baseUrl: 'https://default', vault: 'Vault', apiKey: 'key' },
       context: {}
     });
     classifyClipMock.mockResolvedValue({
@@ -1371,7 +1416,7 @@ describe('clipProcessor', () => {
     });
     selectVaultMock.mockReturnValue({
       vault: null,
-      restConfig: { baseUrl: 'https://default', vault: 'Vault', apiKey: '' },
+      restConfig: { baseUrl: 'https://default', vault: 'Vault', apiKey: 'key' },
       context: {}
     });
     const errorDetail = {

--- a/tests/unit/options/stitchCssRuntimePolish.test.ts
+++ b/tests/unit/options/stitchCssRuntimePolish.test.ts
@@ -159,8 +159,18 @@ describe('Stitch runtime polish CSS contracts', () => {
     expect(stitchCss).toContain('max-height: 360px;');
     expect(stitchCss).toContain('.domain-mapping-table-scroll thead th');
     expect(stitchCss).toContain('.resource-modal--session.is-collapsed .surface-window-header');
-    expect(stitchCss).toContain('grid-template-columns: auto minmax(0, auto);');
+    expect(stitchCss).toContain('grid-template-columns: minmax(0, max-content);');
     expect(stitchCss).toContain('justify-content: center;');
+    expect(stitchCss).toContain('justify-items: center;');
+    expect(stitchCss).toMatch(
+      /\.resource-modal--session\.is-collapsed\s+\.surface-window-brand\s*{[^}]*display:\s*inline-flex;[^}]*align-items:\s*center;[^}]*justify-content:\s*center;/
+    );
+    expect(stitchCss).toMatch(
+      /\.resource-modal--session\.is-collapsed\s+\.surface-window-icon\s*{[^}]*flex:\s*0\s+0\s+var\(--session-header-icon-size\);[^}]*transform:\s*none;/
+    );
+    expect(stitchCss).toMatch(
+      /\.resource-modal--session\.is-collapsed\s+\.surface-window-title\s*{[^}]*left:\s*auto;[^}]*top:\s*auto;[^}]*text-align:\s*center;/
+    );
   });
 
   it('uses green for active video screenshot timestamp dots', () => {

--- a/tests/unit/shared/exportDestination.test.ts
+++ b/tests/unit/shared/exportDestination.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getOutputTemplatePreset } from '@shared/config';
 import {
+  hasConfiguredVaultTarget,
   resolveExportPath,
   resolveTemplateKeyForPayloadType,
   toDownloadsFilename,
@@ -67,5 +68,39 @@ describe('exportDestination path preview', () => {
     ['folder/.hidden.md', '.hidden.md']
   ])('normalizes downloads filename %s to %s', (resolvedPath, expected) => {
     expect(toDownloadsFilename(resolvedPath)).toBe(expected);
+  });
+
+  it('treats local folder vaults as configured export targets without requiring REST keys', () => {
+    expect(
+      hasConfiguredVaultTarget({
+        rest: {
+          baseUrl: '',
+          vault: '',
+          apiKey: ''
+        },
+        templates: {
+          article: '',
+          video: '',
+          fragment: '',
+          reading: '',
+          ai: ''
+        },
+        domainMappings: {},
+        vaultRouter: {
+          vaults: [
+            {
+              id: 'local',
+              name: 'Local Vault',
+              httpsUrl: '',
+              httpUrl: '',
+              vault: '',
+              apiKey: '',
+              localFolderId: 'folder-local',
+              localFolderName: 'Local Vault'
+            }
+          ]
+        }
+      })
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- fall back full-page/article clip saves to Downloads when no writable vault target is configured
- treat local folder vaults as configured export targets even without REST API keys
- center reader/video collapsed session panel icon and title layout

## Verification
- pnpm vitest run tests/unit/options/stitchCssRuntimePolish.test.ts tests/unit/background/clipProcessor.test.ts tests/unit/shared/exportDestination.test.ts
- pnpm typecheck
- pnpm lint:type-any:ratchet
- pnpm build

## Independent audit
- Subagent review found no blocking findings; only noted future hardening for revoked local-folder permission fallback behavior.