### PR TITLE
Fix Firefox runtime boundaries and reader note focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ yarn.lock
 pnpm-lock.yaml
 
 # Archives
+*.zip
 *.tar.gz
 *.rar
 

--- a/src/background/listeners/runtimeMessages.ts
+++ b/src/background/listeners/runtimeMessages.ts
@@ -13,7 +13,7 @@ import {
   isTestVaultConnectionMessage
 } from '../../shared/types';
 import { ClipPayloadSchema } from '../../shared/schemas';
-import { isTrackUsageEventMessage } from '../../shared/types/analytics';
+import { createAnalyticsEventAck, isTrackUsageEventMessage } from '../../shared/types/analytics';
 import {
   errorHandler,
   isAppError,
@@ -253,7 +253,7 @@ export function registerRuntimeMessageListener(
       if (activationMilestone) {
         void trackActivationMilestoneIfNeeded(activationMilestone);
       }
-      return;
+      return createAnalyticsEventAck();
     }
 
     if (isGetTabContextMessage(message)) {

--- a/src/background/services/videoScreenshotCacheService.ts
+++ b/src/background/services/videoScreenshotCacheService.ts
@@ -64,10 +64,15 @@ function deserializeScreenshot(
   screenshot: SerializedVideoScreenshotCacheScreenshot
 ): VideoCaptureScreenshot {
   const blob = serializedAttachmentContentToBlob(
-    {
-      kind: 'base64',
-      binary: screenshot.content
-    },
+    screenshot.content
+      ? {
+          kind: 'base64',
+          binary: screenshot.content
+        }
+      : {
+          kind: 'legacyDataUrl',
+          dataUrl: screenshot.dataUrl ?? ''
+        },
     screenshot.mimeType
   );
 
@@ -79,7 +84,7 @@ function deserializeScreenshot(
     content: {
       kind: 'blob',
       blob,
-      byteLength: screenshot.content.byteLength
+      byteLength: blob.size
     }
   };
 }

--- a/src/content/bootstrap.ts
+++ b/src/content/bootstrap.ts
@@ -1,6 +1,7 @@
 import { createScopedRegistry, registry, TOKENS, type ScopedServiceRegistry } from '../shared/di';
 import { createErrorHandler, type ErrorHandler } from '../shared/errors/errorHandler';
 import { registerGlobalErrorBoundary } from '../shared/errors/globalErrorBoundary';
+import { shouldReportContentGlobalError } from './contentErrorSourcePolicy';
 import {
   configureGlobalStateManagerStorage,
   createGlobalStateManager
@@ -156,6 +157,7 @@ export class ContentScriptContext {
       metadata: {
         extensionContext: 'content'
       },
+      shouldReport: shouldReportContentGlobalError,
       target: window
     });
     this.initializeErrorAnalytics(resolvedStorage, errorHandler);

--- a/src/content/contentErrorSourcePolicy.ts
+++ b/src/content/contentErrorSourcePolicy.ts
@@ -1,0 +1,106 @@
+import type { GlobalErrorBoundaryReport } from '../shared/errors/globalErrorBoundary';
+
+const EXTENSION_PROTOCOLS = new Set([
+  'chrome-extension:',
+  'moz-extension:',
+  'safari-web-extension:'
+]);
+const PAGE_PROTOCOLS = new Set(['http:', 'https:']);
+const IGNORED_BROWSER_ERROR_MESSAGES = new Set([
+  'ResizeObserver loop completed with undelivered notifications.',
+  'ResizeObserver loop limit exceeded'
+]);
+const SOURCE_URL_PATTERN =
+  /\b(?:chrome-extension|moz-extension|safari-web-extension|https?):\/\/[^\s)]+/giu;
+
+export function shouldReportContentGlobalError(report: GlobalErrorBoundaryReport): boolean {
+  if (isIgnoredBrowserError(report)) {
+    return false;
+  }
+
+  const filename =
+    report.event instanceof ErrorEvent && report.event.filename ? report.event.filename : null;
+  if (filename) {
+    return shouldReportSourceUrl(filename);
+  }
+
+  const stackDecision = shouldReportReasonStack(report.reason);
+  return stackDecision ?? true;
+}
+
+function isIgnoredBrowserError(report: GlobalErrorBoundaryReport): boolean {
+  const message = getReasonMessage(report.reason) ?? getEventMessage(report.event);
+  return message !== null && IGNORED_BROWSER_ERROR_MESSAGES.has(message.trim());
+}
+
+function getReasonMessage(reason: GlobalErrorBoundaryReport['reason']): string | null {
+  if (reason instanceof Error) {
+    return reason.message;
+  }
+  if (typeof reason === 'string') {
+    return reason;
+  }
+  if (typeof reason === 'object' && reason !== null && hasStringMessage(reason)) {
+    return reason.message;
+  }
+  return null;
+}
+
+function getEventMessage(event: Event): string | null {
+  return event instanceof ErrorEvent && typeof event.message === 'string' ? event.message : null;
+}
+
+function shouldReportReasonStack(reason: GlobalErrorBoundaryReport['reason']): boolean | null {
+  const stack =
+    reason instanceof Error && typeof reason.stack === 'string'
+      ? reason.stack
+      : typeof reason === 'object' && reason !== null && hasStringStack(reason)
+        ? reason.stack
+        : null;
+  if (!stack) {
+    return null;
+  }
+
+  const sources = stack.match(SOURCE_URL_PATTERN) ?? [];
+  if (sources.some(isExtensionSourceUrl)) {
+    return true;
+  }
+  if (sources.some(isPageSourceUrl)) {
+    return false;
+  }
+  return null;
+}
+
+function shouldReportSourceUrl(sourceUrl: string): boolean {
+  if (isExtensionSourceUrl(sourceUrl)) {
+    return true;
+  }
+  if (isPageSourceUrl(sourceUrl)) {
+    return false;
+  }
+  return true;
+}
+
+function isExtensionSourceUrl(sourceUrl: string): boolean {
+  return isUrlWithProtocol(sourceUrl, EXTENSION_PROTOCOLS);
+}
+
+function isPageSourceUrl(sourceUrl: string): boolean {
+  return isUrlWithProtocol(sourceUrl, PAGE_PROTOCOLS);
+}
+
+function isUrlWithProtocol(sourceUrl: string, protocols: ReadonlySet<string>): boolean {
+  try {
+    return protocols.has(new URL(sourceUrl).protocol);
+  } catch {
+    return false;
+  }
+}
+
+function hasStringMessage(value: object): value is { message: string } {
+  return 'message' in value && typeof value.message === 'string';
+}
+
+function hasStringStack(value: object): value is { stack: string } {
+  return 'stack' in value && typeof value.stack === 'string';
+}

--- a/src/content/reader/application/readerSessionView.ts
+++ b/src/content/reader/application/readerSessionView.ts
@@ -11,6 +11,10 @@ export interface ReaderPanelEditingSnapshot {
   pendingNoteFocusHighlightId: string | null;
 }
 
+export interface ReaderPanelRenderOptions {
+  focusHighlightId?: string | null;
+}
+
 export interface ReaderSessionViewOptions {
   onCommentDraftChange?: (drafts: SessionCommentDraftSnapshot) => void;
 }
@@ -21,7 +25,7 @@ export interface ReaderSessionView {
   updateHint(message: string): void;
   updateTexts(texts: ReaderPanelTexts): void;
   updateDestination?(destination: ExportDestinationSurfacePreview | undefined): void;
-  setHighlights(highlights: ReaderPanelHighlight[]): void;
+  setHighlights(highlights: ReaderPanelHighlight[], options?: ReaderPanelRenderOptions): void;
   snapshotCommentDrafts(): SessionCommentDraftSnapshot;
   hydrateCommentDrafts(drafts: SessionCommentDraftSnapshot): void;
   clearCommentDraft(id: string): void;

--- a/src/content/reader/highlightController.ts
+++ b/src/content/reader/highlightController.ts
@@ -42,7 +42,7 @@ export class ReaderHighlightController {
 
     this.highlights.push(highlight);
     this.options.highlightManager.sortByDocumentOrder(this.highlights);
-    this.syncPanel('panel');
+    this.syncPanel('panel', { focusHighlightId: highlight.id });
   }
 
   ingestExternalHighlight(
@@ -127,8 +127,11 @@ export class ReaderHighlightController {
     this.highlights = [...highlights];
   }
 
-  private syncPanel(state: 'panel' | 'noHighlights'): void {
-    this.options.panelCoordinator.updateHighlights(this.highlights);
+  private syncPanel(
+    state: 'panel' | 'noHighlights',
+    options: { focusHighlightId?: string | null } = {}
+  ): void {
+    this.options.panelCoordinator.updateHighlights(this.highlights, options);
     this.options.panelCoordinator.applyHint(state, this.highlights.length);
   }
 

--- a/src/content/reader/panelCoordinator.ts
+++ b/src/content/reader/panelCoordinator.ts
@@ -1,6 +1,7 @@
 import type { ReaderPanelCallbacks } from './application/readerPanelModel';
 import type {
   ReaderPanelEditingSnapshot,
+  ReaderPanelRenderOptions,
   ReaderSessionView,
   ReaderSessionViewFactory
 } from './application/readerSessionView';
@@ -54,11 +55,14 @@ export class ReaderPanelCoordinator {
     }
   }
 
-  updateHighlights(highlights: ReaderHighlightRecord[]): void {
+  updateHighlights(
+    highlights: ReaderHighlightRecord[],
+    options: ReaderPanelRenderOptions = {}
+  ): void {
     if (!this.presenter) {
       return;
     }
-    this.presenter.render(highlights);
+    this.presenter.render(highlights, options);
     this.applyHint(this.currentHintState, highlights.length);
   }
 

--- a/src/content/reader/panelPresenter.ts
+++ b/src/content/reader/panelPresenter.ts
@@ -1,5 +1,5 @@
 import type { ReaderPanelHighlight, ReaderPanelTexts } from './application/readerPanelModel';
-import type { ReaderSessionView } from './application/readerSessionView';
+import type { ReaderPanelRenderOptions, ReaderSessionView } from './application/readerSessionView';
 import type { ReaderHighlightRecord } from './services/highlightManager';
 import { BasePanelPresenter } from '../shared/panels/basePanelPresenter';
 
@@ -17,7 +17,7 @@ export class ReaderPanelPresenter extends BasePanelPresenter<ReaderSessionView> 
     this.view.updateTexts(texts);
   }
 
-  render(highlights: ReaderHighlightRecord[]): void {
+  render(highlights: ReaderHighlightRecord[], options: ReaderPanelRenderOptions = {}): void {
     const items: ReaderPanelHighlight[] = highlights.map((highlight, index) => {
       const reconstructed = this.utils.reconstructText(highlight);
       return {
@@ -31,6 +31,6 @@ export class ReaderPanelPresenter extends BasePanelPresenter<ReaderSessionView> 
       };
     });
     this.view.updateCount(items.length);
-    this.view.setHighlights(items);
+    this.view.setHighlights(items, options);
   }
 }

--- a/src/content/reader/sessionOperations.ts
+++ b/src/content/reader/sessionOperations.ts
@@ -161,7 +161,7 @@ export function applyReaderHighlightFromRange(
     );
 
   context.state.highlights.push(highlight);
-  syncReaderHighlightsUi(context);
+  syncReaderHighlightsUi(context, { focusHighlightId: highlight.id });
   context.panelCoordinator.applyHint('panel', context.state.highlights.length);
   return highlight;
 }
@@ -582,9 +582,12 @@ export async function submitReaderHighlightEdit(
   });
 }
 
-function syncReaderHighlightsUi(context: ReaderSessionOperationContext): void {
+function syncReaderHighlightsUi(
+  context: ReaderSessionOperationContext,
+  options: { focusHighlightId?: string | null } = {}
+): void {
   context.highlightManager.sortByDocumentOrder(context.state.highlights);
-  context.panelCoordinator.updateHighlights(context.state.highlights);
+  context.panelCoordinator.updateHighlights(context.state.highlights, options);
 }
 
 function queueReaderDraftPersistence(context: ReaderSessionOperationContext): void {
@@ -768,14 +771,12 @@ function collectFailureHints(error: unknown, seen = new Set<unknown>()): string 
     return '';
   }
   seen.add(error);
-
   const hints: string[] = [];
   const push = (value: unknown) => {
     if (typeof value === 'string' && value.trim()) {
       hints.push(value.trim().toLowerCase());
     }
   };
-
   if (typeof error === 'string') {
     push(error);
   } else if (error instanceof Error) {
@@ -794,7 +795,6 @@ function collectFailureHints(error: unknown, seen = new Set<unknown>()): string 
     }
     push(collectFailureHints(error.cause, seen));
   }
-
   return hints.join('\n');
 }
 

--- a/src/content/reader/ui/ReaderDialogPanel.ts
+++ b/src/content/reader/ui/ReaderDialogPanel.ts
@@ -3,7 +3,10 @@ import type {
   ReaderPanelHighlight,
   ReaderPanelTexts
 } from '../application/readerPanelModel';
-import type { ReaderPanelEditingSnapshot } from '../application/readerSessionView';
+import type {
+  ReaderPanelEditingSnapshot,
+  ReaderPanelRenderOptions
+} from '../application/readerSessionView';
 import type { UiMountable } from '@ui/hosts/shared/contract';
 import type { PopupCoordinator } from '@content/runtime/popupCoordinator';
 import { resolveContentPopupCoordinator } from '@content/runtime/popupCoordinatorAccess';
@@ -125,9 +128,9 @@ export class ReaderDialogPanel implements UiMountable<
       this.texts = { ...this.texts, hint: payload.hint };
     }
     if (payload.highlights) {
-      const newestHighlight = this.applyHighlights(payload.highlights);
+      const focusTargetHighlight = this.applyHighlights(payload.highlights);
       this.rerender({ captureDrafts: false });
-      this.focusHighlightNoteInput(newestHighlight?.id);
+      this.focusHighlightNoteInput(focusTargetHighlight?.id);
       return this.renderRoot;
     }
     this.rerender();
@@ -157,10 +160,10 @@ export class ReaderDialogPanel implements UiMountable<
     this.rerender();
   }
 
-  setHighlights(highlights: ReaderPanelHighlight[]): void {
-    const newestHighlight = this.applyHighlights(highlights);
+  setHighlights(highlights: ReaderPanelHighlight[], options: ReaderPanelRenderOptions = {}): void {
+    const focusTargetHighlight = this.applyHighlights(highlights, options);
     this.rerender();
-    this.focusHighlightNoteInput(newestHighlight?.id);
+    this.focusHighlightNoteInput(focusTargetHighlight?.id);
   }
 
   stopEditing(): void {
@@ -335,22 +338,38 @@ export class ReaderDialogPanel implements UiMountable<
     );
   }
 
-  private applyHighlights(highlights: ReaderPanelHighlight[]): ReaderPanelHighlight | undefined {
+  private applyHighlights(
+    highlights: ReaderPanelHighlight[],
+    options: ReaderPanelRenderOptions = {}
+  ): ReaderPanelHighlight | undefined {
     this.commentDrafts.captureRenderedInputs();
     const previousCount = this.highlights.length;
-    const shouldExpandForNewHighlight = previousCount > 0 && highlights.length > previousCount;
+    const focusTargetHighlight = this.resolveHighlightFocusTarget(
+      highlights,
+      options.focusHighlightId
+    );
+    const shouldExpandForNewHighlight = previousCount > 0 && Boolean(focusTargetHighlight);
     if (this.collapsePersistence.value && shouldExpandForNewHighlight) {
       this.collapsePersistence.set(false, { persist: true, rerender: false });
     }
     this.highlights = [...highlights];
     this.highlightCount = highlights.length;
     this.commentDrafts.reconcile(this.highlights);
-    const newestHighlight = highlights.length > previousCount ? highlights.at(-1) : undefined;
-    if (newestHighlight?.id) {
-      this.editingHighlightId = newestHighlight.id;
-      this.pendingNoteFocusHighlightId = newestHighlight.id;
+    if (focusTargetHighlight?.id) {
+      this.editingHighlightId = focusTargetHighlight.id;
+      this.pendingNoteFocusHighlightId = focusTargetHighlight.id;
     }
-    return newestHighlight;
+    return focusTargetHighlight;
+  }
+
+  private resolveHighlightFocusTarget(
+    highlights: ReaderPanelHighlight[],
+    focusHighlightId: string | null | undefined
+  ): ReaderPanelHighlight | undefined {
+    if (!focusHighlightId) {
+      return undefined;
+    }
+    return highlights.find((highlight) => highlight.id === focusHighlightId);
   }
 
   private focusHighlightNoteInput(highlightId: string | null | undefined): void {

--- a/src/content/shared/shadowStyleBridge.ts
+++ b/src/content/shared/shadowStyleBridge.ts
@@ -1,6 +1,7 @@
 const MANAGED_FALLBACK_ATTR = 'data-aiob-style-bridge';
 
 const managedSheetsByRoot = new WeakMap<ShadowRoot, Map<string, CSSStyleSheet>>();
+const constructableStylesBlockedRoots = new WeakSet<ShadowRoot>();
 
 // Cross-browser policy:
 // - Chromium content UIs can use constructed stylesheets directly.
@@ -35,23 +36,7 @@ export function applyManagedShadowStyle(
   cssText: string,
   sheet: CSSStyleSheet | null
 ): void {
-  if (sheet) {
-    detachManagedFallbackStyle(shadowRoot, key);
-
-    const managedSheets = managedSheetsByRoot.get(shadowRoot) ?? new Map<string, CSSStyleSheet>();
-    const previousSheet = managedSheets.get(key) ?? null;
-    managedSheets.set(key, sheet);
-    managedSheetsByRoot.set(shadowRoot, managedSheets);
-
-    const managedSheetSet = new Set(managedSheets.values());
-    const nextSheets = getAdoptedStyleSheetArray(shadowRoot).filter((entry) => {
-      if (entry === previousSheet) {
-        return false;
-      }
-      return !managedSheetSet.has(entry);
-    });
-    nextSheets.push(...managedSheets.values());
-    shadowRoot.adoptedStyleSheets = nextSheets;
+  if (sheet && tryApplyManagedSheet(shadowRoot, key, sheet)) {
     return;
   }
 
@@ -86,12 +71,56 @@ function detachManagedSheet(shadowRoot: ShadowRoot, key: string): void {
     return;
   }
   managedSheets.delete(key);
-  shadowRoot.adoptedStyleSheets = getAdoptedStyleSheetArray(shadowRoot).filter(
-    (entry) => entry !== sheet
-  );
+  try {
+    shadowRoot.adoptedStyleSheets = getAdoptedStyleSheetArray(shadowRoot).filter(
+      (entry) => entry !== sheet
+    );
+  } catch {
+    constructableStylesBlockedRoots.add(shadowRoot);
+    managedSheetsByRoot.delete(shadowRoot);
+    return;
+  }
   if (managedSheets.size === 0) {
     managedSheetsByRoot.delete(shadowRoot);
   }
+}
+
+function tryApplyManagedSheet(shadowRoot: ShadowRoot, key: string, sheet: CSSStyleSheet): boolean {
+  if (constructableStylesBlockedRoots.has(shadowRoot)) {
+    return false;
+  }
+
+  const managedSheets = managedSheetsByRoot.get(shadowRoot) ?? new Map<string, CSSStyleSheet>();
+  const previousSheet = managedSheets.get(key) ?? null;
+
+  managedSheets.set(key, sheet);
+  managedSheetsByRoot.set(shadowRoot, managedSheets);
+
+  try {
+    const managedSheetSet = new Set(managedSheets.values());
+    const nextSheets = getAdoptedStyleSheetArray(shadowRoot).filter((entry) => {
+      if (entry === previousSheet) {
+        return false;
+      }
+      return !managedSheetSet.has(entry);
+    });
+    nextSheets.push(...managedSheets.values());
+    shadowRoot.adoptedStyleSheets = nextSheets;
+  } catch {
+    if (previousSheet) {
+      managedSheets.set(key, previousSheet);
+    } else {
+      managedSheets.delete(key);
+    }
+    if (managedSheets.size === 0) {
+      managedSheetsByRoot.delete(shadowRoot);
+    }
+    constructableStylesBlockedRoots.add(shadowRoot);
+    return false;
+  }
+
+  detachManagedFallbackStyle(shadowRoot, key);
+  return true;
 }
 
 function getAdoptedStyleSheetArray(shadowRoot: ShadowRoot): CSSStyleSheet[] {

--- a/src/content/shared/shadowStyleBridge.ts
+++ b/src/content/shared/shadowStyleBridge.ts
@@ -44,7 +44,7 @@ export function applyManagedShadowStyle(
     managedSheetsByRoot.set(shadowRoot, managedSheets);
 
     const managedSheetSet = new Set(managedSheets.values());
-    const nextSheets = shadowRoot.adoptedStyleSheets.filter((entry) => {
+    const nextSheets = getAdoptedStyleSheetArray(shadowRoot).filter((entry) => {
       if (entry === previousSheet) {
         return false;
       }
@@ -86,10 +86,16 @@ function detachManagedSheet(shadowRoot: ShadowRoot, key: string): void {
     return;
   }
   managedSheets.delete(key);
-  shadowRoot.adoptedStyleSheets = shadowRoot.adoptedStyleSheets.filter((entry) => entry !== sheet);
+  shadowRoot.adoptedStyleSheets = getAdoptedStyleSheetArray(shadowRoot).filter(
+    (entry) => entry !== sheet
+  );
   if (managedSheets.size === 0) {
     managedSheetsByRoot.delete(shadowRoot);
   }
+}
+
+function getAdoptedStyleSheetArray(shadowRoot: ShadowRoot): CSSStyleSheet[] {
+  return Array.from(shadowRoot.adoptedStyleSheets);
 }
 
 function ensureManagedFallbackStyle(shadowRoot: ShadowRoot, key: string): HTMLStyleElement {

--- a/src/content/video/sessionDependencies.ts
+++ b/src/content/video/sessionDependencies.ts
@@ -8,8 +8,13 @@ import type { MessagingService } from '../../platform/interfaces/messaging';
 import type { StorageService } from '../../platform/interfaces/storage';
 import type { RuntimeService } from '../../platform/interfaces/runtime';
 import type { SupportProgressReporter } from '../runtime/supportProgress';
-import { createVisibleTabVideoFrameScreenshotCapture } from './videoVisibleTabScreenshot';
+import {
+  createVisibleTabVideoFrameScreenshotCapture,
+  createVisibleTabVideoFrameScreenshotDataUrlCapture
+} from './videoVisibleTabScreenshot';
 import { createVideoScreenshotCacheClientRepository } from './videoScreenshotCacheClientRepository';
+import { captureVideoFrameScreenshotDataUrl } from './videoFrameScreenshot';
+import { isFirefox } from '../../shared/utils/browserDetection';
 
 export interface VideoSessionPlatformDependencies {
   // Content composition root now passes the primary repository contract.
@@ -25,6 +30,7 @@ export function createVideoSessionDependencies(
   deps: VideoSessionPlatformDependencies
 ): VideoSessionDependencies {
   const runtime = deps.runtime;
+  const firefox = isFirefox();
   return {
     viewFactory: createVideoPanelViewFactory(
       runtime
@@ -37,9 +43,12 @@ export function createVideoSessionDependencies(
     videoRepository:
       deps.videoRepository ?? resolveRepository<IVideoRepository>(DI_TOKENS.IVideoRepository),
     storage: deps.storage,
+    ...(firefox ? { captureVideoFrameScreenshot: captureVideoFrameScreenshotDataUrl } : {}),
     ...(deps.messaging
       ? {
-          captureVisibleVideoFrameScreenshot: createVisibleTabVideoFrameScreenshotCapture({
+          captureVisibleVideoFrameScreenshot: (firefox
+            ? createVisibleTabVideoFrameScreenshotDataUrlCapture
+            : createVisibleTabVideoFrameScreenshotCapture)({
             messaging: deps.messaging
           }),
           screenshotCacheRepository: createVideoScreenshotCacheClientRepository({

--- a/src/content/video/sessionTypes.ts
+++ b/src/content/video/sessionTypes.ts
@@ -6,6 +6,7 @@ import type { VideoSessionViewFactory } from './application/videoSessionView';
 import type { SupportProgressReporter } from '../runtime/supportProgress';
 import type { VideoVisibleFrameScreenshotCapture } from './videoVisibleTabScreenshot';
 import type { VideoScreenshotCacheRepository } from './videoScreenshotCacheRepository';
+import type { VideoScreenshotFrameCapture } from './videoScreenshotPreparationQueueTypes';
 
 export type VideoSessionAddCaptureOptions = {
   comment?: string;
@@ -25,6 +26,7 @@ export interface VideoSessionDependencies {
     local: StorageAreaService;
     sync: StorageAreaService;
   };
+  captureVideoFrameScreenshot?: VideoScreenshotFrameCapture;
   captureVisibleVideoFrameScreenshot?: VideoVisibleFrameScreenshotCapture;
   screenshotCacheRepository?: VideoScreenshotCacheRepository;
   showSupportProgress?: SupportProgressReporter;

--- a/src/content/video/videoFrameScreenshot.ts
+++ b/src/content/video/videoFrameScreenshot.ts
@@ -1,13 +1,11 @@
 import type { VideoCaptureScreenshot, VideoCaptureScreenshotContent } from './types';
 import {
   encodeCanvasToBudgetedBlob,
-  resizeCanvasToMaxEdge,
-  SCREENSHOT_MIME_TYPE,
-  VIDEO_SCREENSHOT_ENCODING_MAX_EDGE_LADDER,
-  VIDEO_SCREENSHOT_ENCODING_QUALITY_LADDER
+  encodeCanvasToBudgetedDataUrl,
+  isJpegDataUrl,
+  SCREENSHOT_DATA_URL_PREFIX,
+  SCREENSHOT_MIME_TYPE
 } from './videoScreenshotEncoding';
-
-const SCREENSHOT_DATA_URL_PREFIX = `data:${SCREENSHOT_MIME_TYPE};base64,`;
 
 export function captureVideoFrameScreenshot(
   video: HTMLVideoElement,
@@ -47,11 +45,36 @@ export async function captureVideoFrameScreenshotAsync(
   }
 }
 
+export function captureVideoFrameScreenshotDataUrl(
+  video: HTMLVideoElement,
+  timeSec: number,
+  now = Date.now()
+): VideoCaptureScreenshot | null {
+  void timeSec;
+  try {
+    const canvas = renderVideoFrameToCanvas(video);
+    if (!canvas) {
+      return null;
+    }
+    return createScreenshotRecordFromDataUrl(encodeCanvasToBudgetedDataUrl(canvas), now);
+  } catch (error) {
+    console.warn('[VideoSession] Failed to capture video frame screenshot:', error);
+    return null;
+  }
+}
+
 export function createVideoFrameScreenshotFromBlob(
   blob: Blob | null,
   now = Date.now()
 ): VideoCaptureScreenshot | null {
   return createScreenshotRecord(createBlobContent(blob), now);
+}
+
+export function createVideoFrameScreenshotFromDataUrl(
+  dataUrl: string | null,
+  now = Date.now()
+): VideoCaptureScreenshot | null {
+  return createScreenshotRecordFromDataUrl(dataUrl, now);
 }
 
 function renderVideoFrameToCanvas(video: HTMLVideoElement): HTMLCanvasElement | null {
@@ -73,15 +96,7 @@ function renderVideoFrameToCanvas(video: HTMLVideoElement): HTMLCanvasElement | 
 }
 
 function encodeCanvasToDataUrl(canvas: HTMLCanvasElement): string | null {
-  const resizedCanvas = resizeCanvasToMaxEdge(canvas, VIDEO_SCREENSHOT_ENCODING_MAX_EDGE_LADDER[0]);
-  if (!resizedCanvas) {
-    return null;
-  }
-  const dataUrl = resizedCanvas.toDataURL(
-    SCREENSHOT_MIME_TYPE,
-    VIDEO_SCREENSHOT_ENCODING_QUALITY_LADDER[0]
-  );
-  return isJpegDataUrl(dataUrl) ? dataUrl : null;
+  return encodeCanvasToBudgetedDataUrl(canvas);
 }
 
 function encodeCanvasToLegacyBlobContent(
@@ -146,8 +161,21 @@ function createScreenshotRecord(
   };
 }
 
-function isJpegDataUrl(dataUrl: string | null): dataUrl is string {
-  return typeof dataUrl === 'string' && dataUrl.startsWith(SCREENSHOT_DATA_URL_PREFIX);
+function createScreenshotRecordFromDataUrl(
+  dataUrl: string | null,
+  now: number
+): VideoCaptureScreenshot | null {
+  if (!isJpegDataUrl(dataUrl)) {
+    return null;
+  }
+  const id = `screenshot-${now}-${Math.random().toString(16).slice(2)}`;
+  return {
+    id,
+    fileName: `file-${formatTimestampSlug(now)}.jpg`,
+    mimeType: SCREENSHOT_MIME_TYPE,
+    capturedAt: now,
+    dataUrl
+  };
 }
 
 function formatTimestampSlug(timestamp: number): string {

--- a/src/content/video/videoScreenshotAttachmentSerialization.ts
+++ b/src/content/video/videoScreenshotAttachmentSerialization.ts
@@ -1,0 +1,35 @@
+import {
+  isLegacyDataUrlForMimeType,
+  serializeBlobAttachmentContent
+} from '../../shared/attachments/clipAttachmentBinary';
+import type { ClipAttachment } from '../../shared/types';
+import type { VideoCaptureScreenshot } from './types';
+
+export async function serializeVideoScreenshotAttachment(
+  screenshot: VideoCaptureScreenshot
+): Promise<ClipAttachment | null> {
+  if (screenshot.content?.kind === 'blob') {
+    try {
+      return {
+        id: screenshot.id,
+        fileName: screenshot.fileName,
+        mimeType: screenshot.mimeType,
+        content: await serializeBlobAttachmentContent(screenshot.content.blob)
+      };
+    } catch {
+      // Firefox can expose page-owned Blob objects through Xray wrappers. Fall through to the
+      // JSON-safe data URL captured at the provider boundary when available.
+    }
+  }
+
+  if (isLegacyDataUrlForMimeType(screenshot.dataUrl, screenshot.mimeType)) {
+    return {
+      id: screenshot.id,
+      fileName: screenshot.fileName,
+      mimeType: screenshot.mimeType,
+      dataUrl: screenshot.dataUrl
+    };
+  }
+
+  return null;
+}

--- a/src/content/video/videoScreenshotCacheClientRepository.ts
+++ b/src/content/video/videoScreenshotCacheClientRepository.ts
@@ -1,7 +1,4 @@
-import {
-  serializeBlobAttachmentContent,
-  serializedAttachmentContentToBlob
-} from '../../shared/attachments/clipAttachmentBinary';
+import { serializedAttachmentContentToBlob } from '../../shared/attachments/clipAttachmentBinary';
 import type { MessagingService } from '../../platform/interfaces/messaging';
 import type { VideoCaptureScreenshot } from './types';
 import type {
@@ -16,17 +13,10 @@ import {
   type VideoScreenshotCacheResponse
 } from './videoScreenshotCacheMessages';
 import type { VideoScreenshotCacheRef } from './videoScreenshotCacheTypes';
+import { serializeVideoScreenshotAttachment } from './videoScreenshotAttachmentSerialization';
 
 export interface VideoScreenshotCacheClientRepositoryOptions {
   messaging: Pick<MessagingService, 'send'>;
-}
-
-function hasBlobContent(
-  screenshot: VideoCaptureScreenshot
-): screenshot is VideoCaptureScreenshot & {
-  content: NonNullable<VideoCaptureScreenshot['content']>;
-} {
-  return screenshot.content?.kind === 'blob';
 }
 
 function errorMessage(error: Error | string): string {
@@ -48,16 +38,18 @@ function isVideoScreenshotCacheResponse(
 }
 
 async function serializeScreenshot(
-  screenshot: VideoCaptureScreenshot & {
-    content: NonNullable<VideoCaptureScreenshot['content']>;
+  screenshot: VideoCaptureScreenshot
+): Promise<SerializedVideoScreenshotCacheScreenshot | null> {
+  const attachment = await serializeVideoScreenshotAttachment(screenshot);
+  if (!attachment) {
+    return null;
   }
-): Promise<SerializedVideoScreenshotCacheScreenshot> {
   return {
     id: screenshot.id,
     fileName: screenshot.fileName,
     mimeType: screenshot.mimeType,
     capturedAt: screenshot.capturedAt,
-    content: await serializeBlobAttachmentContent(screenshot.content.blob)
+    ...('content' in attachment ? { content: attachment.content } : { dataUrl: attachment.dataUrl })
   };
 }
 
@@ -65,10 +57,15 @@ function deserializeScreenshot(
   screenshot: SerializedVideoScreenshotCacheScreenshot
 ): VideoCaptureScreenshot {
   const blob = serializedAttachmentContentToBlob(
-    {
-      kind: 'base64',
-      binary: screenshot.content
-    },
+    screenshot.content
+      ? {
+          kind: 'base64',
+          binary: screenshot.content
+        }
+      : {
+          kind: 'legacyDataUrl',
+          dataUrl: screenshot.dataUrl ?? ''
+        },
     screenshot.mimeType
   );
 
@@ -80,7 +77,7 @@ function deserializeScreenshot(
     content: {
       kind: 'blob',
       blob,
-      byteLength: screenshot.content.byteLength
+      byteLength: blob.size
     }
   };
 }
@@ -111,18 +108,17 @@ export function createVideoScreenshotCacheClientRepository({
 
   return {
     async save(input: VideoScreenshotCacheSaveInput): Promise<VideoScreenshotCacheSaveResult> {
-      if (!hasBlobContent(input.screenshot)) {
-        return {
-          status: 'skipped',
-          reason: 'missing-blob-content'
-        };
-      }
-
-      let screenshot: SerializedVideoScreenshotCacheScreenshot;
+      let screenshot: SerializedVideoScreenshotCacheScreenshot | null;
       try {
         screenshot = await serializeScreenshot(input.screenshot);
       } catch (error) {
         return messageFailure(error instanceof Error ? error : String(error));
+      }
+      if (!screenshot) {
+        return {
+          status: 'skipped',
+          reason: 'missing-blob-content'
+        };
       }
 
       try {

--- a/src/content/video/videoScreenshotCacheMessages.ts
+++ b/src/content/video/videoScreenshotCacheMessages.ts
@@ -1,4 +1,5 @@
 import {
+  isLegacyDataUrlForMimeType,
   isSerializedClipAttachmentBinaryContent,
   type SerializedClipAttachmentBinaryContent
 } from '../../shared/attachments/clipAttachmentBinary';
@@ -20,7 +21,8 @@ export interface SerializedVideoScreenshotCacheScreenshot {
   fileName: string;
   mimeType: VideoCaptureScreenshot['mimeType'];
   capturedAt: number;
-  content: SerializedClipAttachmentBinaryContent;
+  content?: SerializedClipAttachmentBinaryContent;
+  dataUrl?: string;
 }
 
 export type VideoScreenshotCacheMessage =
@@ -169,8 +171,16 @@ function normalizeSerializedScreenshot(
   const mimeType = value.mimeType === 'image/jpeg' ? value.mimeType : null;
   const capturedAt = normalizeTimestamp(value.capturedAt);
   const content = isSerializedClipAttachmentBinaryContent(value.content) ? value.content : null;
+  const dataUrl =
+    mimeType && isLegacyDataUrlForMimeType(value.dataUrl, mimeType) ? value.dataUrl : null;
 
-  if (id === null || fileName === null || mimeType === null || capturedAt === null || !content) {
+  if (
+    id === null ||
+    fileName === null ||
+    mimeType === null ||
+    capturedAt === null ||
+    (content === null && dataUrl === null)
+  ) {
     return null;
   }
 
@@ -179,7 +189,8 @@ function normalizeSerializedScreenshot(
     fileName,
     mimeType,
     capturedAt,
-    content
+    ...(content ? { content } : {}),
+    ...(dataUrl ? { dataUrl } : {})
   };
 }
 

--- a/src/content/video/videoScreenshotEncoding.ts
+++ b/src/content/video/videoScreenshotEncoding.ts
@@ -1,6 +1,7 @@
 import { VIDEO_SCREENSHOT_CACHE_MAX_CONTENT_BYTES } from './videoScreenshotCacheTypes';
 
 export const SCREENSHOT_MIME_TYPE = 'image/jpeg';
+export const SCREENSHOT_DATA_URL_PREFIX = `data:${SCREENSHOT_MIME_TYPE};base64,`;
 export const VIDEO_SCREENSHOT_ENCODING_MAX_BYTES = VIDEO_SCREENSHOT_CACHE_MAX_CONTENT_BYTES;
 export const VIDEO_SCREENSHOT_ENCODING_QUALITY_LADDER = [0.78, 0.7, 0.62] as const;
 export const VIDEO_SCREENSHOT_ENCODING_MAX_EDGE_LADDER = [1280, 960, 720] as const;
@@ -38,6 +39,41 @@ export async function encodeCanvasToBudgetedBlob(
       const normalizedBlob = normalizeBlobMimeType(blob);
       if (normalizedBlob.size <= maxBytes) {
         return normalizedBlob;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function encodeCanvasToBudgetedDataUrl(
+  canvas: HTMLCanvasElement,
+  options?: {
+    maxBytes?: number;
+    qualityLadder?: readonly number[];
+    maxEdgeLadder?: readonly number[];
+  }
+): string | null {
+  const maxBytes =
+    normalizePositiveInteger(options?.maxBytes) ?? VIDEO_SCREENSHOT_ENCODING_MAX_BYTES;
+  const qualityLadder =
+    normalizeNumberSequence(options?.qualityLadder) ?? VIDEO_SCREENSHOT_ENCODING_QUALITY_LADDER;
+  const maxEdgeLadder =
+    normalizeNumberSequence(options?.maxEdgeLadder) ?? VIDEO_SCREENSHOT_ENCODING_MAX_EDGE_LADDER;
+
+  if (qualityLadder.length === 0 || maxEdgeLadder.length === 0) {
+    return null;
+  }
+
+  for (const maxEdge of maxEdgeLadder) {
+    const resizedCanvas = resizeCanvasToMaxEdge(canvas, maxEdge);
+    if (!resizedCanvas) {
+      return null;
+    }
+    for (const quality of qualityLadder) {
+      const dataUrl = encodeCanvasToDataUrl(resizedCanvas, quality);
+      if (isJpegDataUrl(dataUrl) && getJpegDataUrlByteLength(dataUrl) <= maxBytes) {
+        return dataUrl;
       }
     }
   }
@@ -90,10 +126,27 @@ async function encodeCanvasToBlob(
   });
 }
 
+function encodeCanvasToDataUrl(canvas: HTMLCanvasElement, quality: number): string | null {
+  if (typeof canvas.toDataURL !== 'function') {
+    return null;
+  }
+  return canvas.toDataURL(SCREENSHOT_MIME_TYPE, quality);
+}
+
 function normalizeBlobMimeType(blob: Blob): Blob {
   return blob.type === SCREENSHOT_MIME_TYPE
     ? blob
     : new Blob([blob], { type: SCREENSHOT_MIME_TYPE });
+}
+
+export function isJpegDataUrl(dataUrl: string | null): dataUrl is string {
+  return typeof dataUrl === 'string' && dataUrl.startsWith(SCREENSHOT_DATA_URL_PREFIX);
+}
+
+export function getJpegDataUrlByteLength(dataUrl: string): number {
+  const base64 = dataUrl.slice(SCREENSHOT_DATA_URL_PREFIX.length);
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
 }
 
 function resolveResizedCanvasDimensions(

--- a/src/content/video/videoScreenshotExportAttachments.ts
+++ b/src/content/video/videoScreenshotExportAttachments.ts
@@ -1,13 +1,13 @@
 import type { ClipAttachment } from '../../shared/types';
-import { serializeBlobAttachmentContent } from '../../shared/attachments/clipAttachmentBinary';
 import type { VideoTimestampCapture } from './types';
+import { serializeVideoScreenshotAttachment as serializeScreenshotAttachment } from './videoScreenshotAttachmentSerialization';
 
 type SerializedVideoScreenshotAttachments = {
   attachments: ClipAttachment[];
   attachmentIds: Set<string>;
 };
 
-async function serializeVideoScreenshotAttachment(
+async function serializeCaptureScreenshotAttachment(
   capture: VideoTimestampCapture
 ): Promise<ClipAttachment | null> {
   const screenshot = capture.screenshot;
@@ -15,36 +15,14 @@ async function serializeVideoScreenshotAttachment(
     return null;
   }
 
-  if (screenshot.content?.kind === 'blob') {
-    try {
-      return {
-        id: screenshot.id,
-        fileName: screenshot.fileName,
-        mimeType: screenshot.mimeType,
-        content: await serializeBlobAttachmentContent(screenshot.content.blob)
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  if (typeof screenshot.dataUrl === 'string') {
-    return {
-      id: screenshot.id,
-      fileName: screenshot.fileName,
-      mimeType: screenshot.mimeType,
-      dataUrl: screenshot.dataUrl
-    };
-  }
-
-  return null;
+  return serializeScreenshotAttachment(screenshot);
 }
 
 export async function serializeVideoScreenshotAttachments(
   captures: readonly VideoTimestampCapture[]
 ): Promise<SerializedVideoScreenshotAttachments> {
   const attachments = (
-    await Promise.all(captures.map((capture) => serializeVideoScreenshotAttachment(capture)))
+    await Promise.all(captures.map((capture) => serializeCaptureScreenshotAttachment(capture)))
   ).filter((attachment): attachment is ClipAttachment => attachment !== null);
 
   return {

--- a/src/content/video/videoScreenshotPreparationCoordinator.ts
+++ b/src/content/video/videoScreenshotPreparationCoordinator.ts
@@ -2,6 +2,10 @@ import { setTimestampScreenshot } from './screenshotIntent';
 import type { VideoCaptureScreenshot, VideoTimestampCapture } from './types';
 import type { VideoVisibleFrameScreenshotCapture } from './videoVisibleTabScreenshot';
 import type { VideoScreenshotPreparedCallback } from './videoScreenshotPreparationCallbacks';
+import type {
+  CreateVideoScreenshotPreparationQueueArgs,
+  VideoScreenshotFrameCapture
+} from './videoScreenshotPreparationQueueTypes';
 
 interface VideoScreenshotPreparationCoordinatorArgs {
   doc: Document;
@@ -9,6 +13,7 @@ interface VideoScreenshotPreparationCoordinatorArgs {
   getVisibleVideo: () => HTMLVideoElement | null;
   syncPanel: () => void;
   onScreenshotPrepared?: VideoScreenshotPreparedCallback;
+  captureFrame?: VideoScreenshotFrameCapture | undefined;
   captureVisibleFrame?: VideoVisibleFrameScreenshotCapture | undefined;
 }
 
@@ -139,15 +144,20 @@ export class VideoScreenshotPreparationCoordinator {
           return null;
         }
 
-        const queue = createVideoScreenshotPreparationQueue({
+        const queueArgs: CreateVideoScreenshotPreparationQueueArgs = {
           doc: this.args.doc,
           getCaptures: this.args.getCaptures,
           getVisibleVideo: this.args.getVisibleVideo,
-          captureVisibleFrame: this.args.captureVisibleFrame,
           onScreenshotPrepared: (capture, screenshot, source) =>
             this.args.onScreenshotPrepared?.(capture, screenshot, source),
-          syncPanel: this.args.syncPanel
-        });
+          syncPanel: this.args.syncPanel,
+          ...(this.args.captureFrame ? { captureFrame: this.args.captureFrame } : {}),
+          ...(this.args.captureVisibleFrame
+            ? { captureVisibleFrame: this.args.captureVisibleFrame }
+            : {})
+        };
+
+        const queue = createVideoScreenshotPreparationQueue(queueArgs);
 
         if (this.disposed || generation !== this.generation) {
           queue.dispose();

--- a/src/content/video/videoSessionRuntime.ts
+++ b/src/content/video/videoSessionRuntime.ts
@@ -142,6 +142,7 @@ export class VideoSession {
       doc: this.doc,
       getCaptures: () => this.getTimestampCaptures(),
       getVisibleVideo: () => this.state.videoElement,
+      captureFrame: this.dependencies.captureVideoFrameScreenshot,
       captureVisibleFrame: this.dependencies.captureVisibleVideoFrameScreenshot,
       onScreenshotPrepared: (capture, screenshot) => {
         void this.persistPreparedScreenshot(capture, screenshot);

--- a/src/content/video/videoVisibleTabScreenshot.ts
+++ b/src/content/video/videoVisibleTabScreenshot.ts
@@ -3,9 +3,15 @@ import {
   createCaptureVisibleTabScreenshotMessage,
   type CaptureVisibleTabScreenshotResponse
 } from '../../shared/types/videoScreenshotMessages';
-import { createVideoFrameScreenshotFromBlob } from './videoFrameScreenshot';
+import {
+  createVideoFrameScreenshotFromBlob,
+  createVideoFrameScreenshotFromDataUrl
+} from './videoFrameScreenshot';
 import type { VideoCaptureScreenshot } from './types';
-import { encodeCanvasToBudgetedBlob } from './videoScreenshotEncoding';
+import {
+  encodeCanvasToBudgetedBlob,
+  encodeCanvasToBudgetedDataUrl
+} from './videoScreenshotEncoding';
 
 export type VideoVisibleFrameScreenshotCapture = (
   video: HTMLVideoElement,
@@ -21,8 +27,21 @@ export function createVisibleTabVideoFrameScreenshotCapture(args: {
     if (!dataUrl) {
       return null;
     }
-    const blob = await cropVisibleTabScreenshotToVideo(dataUrl, video);
+    const blob = await cropVisibleTabScreenshotToVideoBlob(dataUrl, video);
     return createVideoFrameScreenshotFromBlob(blob, now);
+  };
+}
+
+export function createVisibleTabVideoFrameScreenshotDataUrlCapture(args: {
+  messaging: Pick<MessagingService, 'send'>;
+}): VideoVisibleFrameScreenshotCapture {
+  return async (video, _timeSec, now = Date.now()) => {
+    const dataUrl = await requestVisibleTabScreenshot(args.messaging);
+    if (!dataUrl) {
+      return null;
+    }
+    const croppedDataUrl = await cropVisibleTabScreenshotToVideoDataUrl(dataUrl, video);
+    return createVideoFrameScreenshotFromDataUrl(croppedDataUrl, now);
   };
 }
 
@@ -40,10 +59,26 @@ async function requestVisibleTabScreenshot(
   }
 }
 
-async function cropVisibleTabScreenshotToVideo(
+async function cropVisibleTabScreenshotToVideoBlob(
   dataUrl: string,
   video: HTMLVideoElement
 ): Promise<Blob | null> {
+  const canvas = await cropVisibleTabScreenshotToVideoCanvas(dataUrl, video);
+  return canvas ? await encodeCanvasToBudgetedBlob(canvas) : null;
+}
+
+async function cropVisibleTabScreenshotToVideoDataUrl(
+  dataUrl: string,
+  video: HTMLVideoElement
+): Promise<string | null> {
+  const canvas = await cropVisibleTabScreenshotToVideoCanvas(dataUrl, video);
+  return canvas ? encodeCanvasToBudgetedDataUrl(canvas) : null;
+}
+
+async function cropVisibleTabScreenshotToVideoCanvas(
+  dataUrl: string,
+  video: HTMLVideoElement
+): Promise<HTMLCanvasElement | null> {
   const doc = video.ownerDocument;
   if (!doc.defaultView || !dataUrl.startsWith('data:image/')) {
     return null;
@@ -79,7 +114,7 @@ async function cropVisibleTabScreenshotToVideo(
     crop.width,
     crop.height
   );
-  return await encodeCanvasToBudgetedBlob(canvas);
+  return canvas;
 }
 
 function loadImage(doc: Document, dataUrl: string): Promise<HTMLImageElement> {

--- a/src/platform/services.ts
+++ b/src/platform/services.ts
@@ -16,16 +16,28 @@ import { registry, TOKENS } from '../shared/di';
 import { createFetchRestClient } from '../infrastructure/restClient';
 import { configureSessionDraftRuntimeMessenger } from '../content/sessionDrafts/sessionDraftTabContext';
 import { configureI18nRuntimeLanguageProvider } from '../i18n';
+import { detectBrowser } from '../shared/utils/browserDetection';
 /**
  * 检测当前浏览器环境
  */
 function detectBrowserEnvironment(): 'chrome' | 'firefox' | 'unknown' {
+  const detectedBrowser = detectBrowser();
+  if (
+    (detectedBrowser === 'firefox' || detectedBrowser === 'firefox-mobile') &&
+    typeof browser !== 'undefined' &&
+    browser.runtime
+  ) {
+    return 'firefox';
+  }
+
+  if (typeof browser !== 'undefined' && browser.runtime && typeof chrome === 'undefined') {
+    return 'firefox';
+  }
+
   if (typeof chrome !== 'undefined' && chrome.runtime) {
     return 'chrome';
   }
-  if (typeof browser !== 'undefined' && browser.runtime) {
-    return 'firefox';
-  }
+
   return 'unknown';
 }
 

--- a/src/shared/analytics/analyticsEventMessage.ts
+++ b/src/shared/analytics/analyticsEventMessage.ts
@@ -30,6 +30,10 @@ export type AnalyticsRuntimeEventCompatibilityPayload = {
   };
 }[UsageEventName];
 
+export type AnalyticsRuntimeEventAck = {
+  success: true;
+};
+
 export function createAnalyticsEventMessage<EventName extends UsageEventName>(
   event: EventName,
   params?: UsageEventParamMap[EventName]
@@ -38,6 +42,10 @@ export function createAnalyticsEventMessage<EventName extends UsageEventName>(
     return { type: ANALYTICS_EVENT_MESSAGE, event } as AnalyticsRuntimeEventPayload;
   }
   return { type: ANALYTICS_EVENT_MESSAGE, event, params } as AnalyticsRuntimeEventPayload;
+}
+
+export function createAnalyticsEventAck(): AnalyticsRuntimeEventAck {
+  return { success: true };
 }
 
 export function isAnalyticsRuntimeEventMessage(

--- a/src/shared/errors/globalErrorBoundary.ts
+++ b/src/shared/errors/globalErrorBoundary.ts
@@ -14,6 +14,14 @@ export interface GlobalErrorBoundaryOptions {
   errorHandler?: ErrorHandlerLike;
   metadata?: Record<string, unknown>;
   target?: ErrorBoundaryTarget;
+  shouldReport?: (report: GlobalErrorBoundaryReport) => boolean;
+}
+
+export interface GlobalErrorBoundaryReport {
+  event: Event;
+  eventType: 'error' | 'unhandledrejection';
+  reason: AppError['cause'];
+  metadata: NonNullable<AppError['context']>;
 }
 
 function normalizeThrownError(
@@ -70,32 +78,51 @@ export function registerGlobalErrorBoundary(options: GlobalErrorBoundaryOptions)
 
   const handleErrorEvent: EventListener = (event) => {
     const errorEvent = event as ErrorEvent;
-    const reportedError = buildUnhandledError(
-      'UNHANDLED_ERROR',
-      options.domain,
-      errorEvent.error ?? errorEvent.message,
-      {
-        ...options.metadata,
+    const metadata = {
+      ...options.metadata,
+      eventType: 'error' as const,
+      ...(errorEvent.filename ? { filename: errorEvent.filename } : {}),
+      ...(errorEvent.lineno ? { lineno: errorEvent.lineno } : {}),
+      ...(errorEvent.colno ? { colno: errorEvent.colno } : {})
+    };
+    const reason: AppError['cause'] = errorEvent.error ?? errorEvent.message;
+    if (
+      options.shouldReport?.({
+        event,
         eventType: 'error',
-        ...(errorEvent.filename ? { filename: errorEvent.filename } : {}),
-        ...(errorEvent.lineno ? { lineno: errorEvent.lineno } : {}),
-        ...(errorEvent.colno ? { colno: errorEvent.colno } : {})
-      }
-    );
+        reason,
+        metadata
+      }) === false
+    ) {
+      return;
+    }
+    const reportedError = buildUnhandledError('UNHANDLED_ERROR', options.domain, reason, metadata);
 
     void errorHandler.handle(reportedError, { suppressNotifications: true });
   };
 
   const handleUnhandledRejection: EventListener = (event) => {
     const rejectionEvent = event as PromiseRejectionEvent;
+    const reason: AppError['cause'] = rejectionEvent.reason;
+    const metadata = {
+      ...options.metadata,
+      eventType: 'unhandledrejection' as const
+    };
+    if (
+      options.shouldReport?.({
+        event,
+        eventType: 'unhandledrejection',
+        reason,
+        metadata
+      }) === false
+    ) {
+      return;
+    }
     const reportedError = buildUnhandledError(
       'UNHANDLED_REJECTION',
       options.domain,
-      rejectionEvent.reason,
-      {
-        ...options.metadata,
-        eventType: 'unhandledrejection'
-      }
+      reason,
+      metadata
     );
 
     void errorHandler.handle(reportedError, { suppressNotifications: true });

--- a/src/shared/types/analytics.ts
+++ b/src/shared/types/analytics.ts
@@ -46,6 +46,7 @@ export {
   FUTURE_PRODUCT_EVENT_NAMES,
   INVENTORY_ONLY_EVENT_NAMES,
   RUNTIME_USAGE_EVENT_NAMES,
+  createAnalyticsEventAck,
   createAnalyticsEventMessage,
   getAnalyticsAllowedParams,
   hasRequiredUsageEventParams,
@@ -55,6 +56,7 @@ export {
   sanitizeUsageEventParams
 } from '../analytics';
 export type {
+  AnalyticsRuntimeEventAck,
   AnalyticsRuntimeEventCompatibilityPayload,
   AnalyticsRuntimeEventPayload
 } from '../analytics';

--- a/src/shared/utils/browserDetection.ts
+++ b/src/shared/utils/browserDetection.ts
@@ -9,26 +9,24 @@ export type BrowserType = 'chrome' | 'firefox' | 'firefox-mobile' | 'edge' | 'sa
  * 检测当前浏览器类型
  */
 export function detectBrowser(): BrowserType {
-  // 在扩展环境中检测
-  if (typeof chrome !== 'undefined' && chrome.runtime) {
-    // 检测是否为 Edge（基于 Chromium）
-    if (navigator.userAgent.includes('Edg/')) {
-      return 'edge';
-    }
-    return 'chrome';
+  const userAgent = getNavigatorUserAgent().toLowerCase();
+  const browserFromUserAgent = detectBrowserFromUserAgent(userAgent);
+  if (browserFromUserAgent !== 'unknown') {
+    return browserFromUserAgent;
   }
 
   if (typeof browser !== 'undefined' && browser.runtime) {
-    // Firefox 环境
-    if (navigator.userAgent.includes('Mobile')) {
-      return 'firefox-mobile';
-    }
     return 'firefox';
   }
 
-  // 在网页环境中检测
-  const userAgent = navigator.userAgent.toLowerCase();
+  if (typeof chrome !== 'undefined' && chrome.runtime) {
+    return 'chrome';
+  }
 
+  return 'unknown';
+}
+
+function detectBrowserFromUserAgent(userAgent: string): BrowserType {
   if (userAgent.includes('firefox')) {
     return userAgent.includes('mobile') ? 'firefox-mobile' : 'firefox';
   }
@@ -46,6 +44,10 @@ export function detectBrowser(): BrowserType {
   }
 
   return 'unknown';
+}
+
+function getNavigatorUserAgent(): string {
+  return typeof navigator !== 'undefined' ? navigator.userAgent : '';
 }
 
 /**
@@ -70,7 +72,7 @@ export function isMobile(): boolean {
   const browser = detectBrowser();
   return (
     browser === 'firefox-mobile' ||
-    /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+    /Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(getNavigatorUserAgent())
   );
 }
 
@@ -120,7 +122,7 @@ export function addBrowserClassToHtml(): void {
  * 获取浏览器版本信息
  */
 export function getBrowserVersion(): string {
-  const userAgent = navigator.userAgent;
+  const userAgent = getNavigatorUserAgent();
   const browser = detectBrowser();
 
   let match: RegExpMatchArray | null = null;

--- a/tests/e2e/phase4/shadow-dom.test.ts
+++ b/tests/e2e/phase4/shadow-dom.test.ts
@@ -88,6 +88,30 @@ describe('phase4/shadow-dom adoptedStyleSheets', () => {
     );
   });
 
+  it('falls back to inline style tags when Firefox blocks shadow adoptedStyleSheets access', async () => {
+    await withDomEnvironment(
+      '<!DOCTYPE html><html><body></body></html>',
+      { globals: DOM_GLOBALS },
+      async ({ document, window }) => {
+        const restoreFetch = stubClipperFetch(window);
+        const restore = enableConstructableStyles(window, { shadowAccessBlocked: true });
+        try {
+          await clipperStyleSheetManager.initialize();
+
+          const host = document.createElement('div');
+          document.body.append(host);
+          const shadow = host.attachShadow({ mode: 'open' });
+
+          expect(() => clipperStyleSheetManager.applyTo(shadow)).not.toThrow();
+          expect(shadow.querySelectorAll('style')).toHaveLength(2);
+        } finally {
+          restore();
+          restoreFetch();
+        }
+      }
+    );
+  });
+
   it('falls back to inline style tags when constructable styles are unavailable', async () => {
     await withDomEnvironment(
       '<!DOCTYPE html><html><body></body></html>',
@@ -146,7 +170,7 @@ function stubClipperFetch(window: WindowShim): () => void {
 
 function enableConstructableStyles(
   window: WindowShim,
-  options: { firefoxCollection?: boolean } = {}
+  options: { firefoxCollection?: boolean; shadowAccessBlocked?: boolean } = {}
 ): () => void {
   const globals = globalThis as typeof globalThis & {
     Document?: typeof window.Document;
@@ -169,11 +193,15 @@ function enableConstructableStyles(
     'adoptedStyleSheets'
   );
 
-  Object.defineProperty(docProto, 'adoptedStyleSheets', createAdoptedDescriptor<Document>(options));
+  Object.defineProperty(
+    docProto,
+    'adoptedStyleSheets',
+    createAdoptedDescriptor<Document>(window, options)
+  );
   Object.defineProperty(
     shadowProto,
     'adoptedStyleSheets',
-    createAdoptedDescriptor<ShadowRoot>(options)
+    createAdoptedDescriptor<ShadowRoot>(window, options)
   );
 
   class FakeConstructableStyleSheet {
@@ -206,11 +234,15 @@ function enableConstructableStyles(
 }
 
 function createAdoptedDescriptor<T extends Document | ShadowRoot>(
-  options: { firefoxCollection?: boolean } = {}
+  window: WindowShim,
+  options: { firefoxCollection?: boolean; shadowAccessBlocked?: boolean } = {}
 ): PropertyDescriptor {
   return {
     configurable: true,
     get(this: T & { [INTERNAL_DOC_SHEETS]?: CSSStyleSheet[] }) {
+      if (this instanceof window.ShadowRoot && options.shadowAccessBlocked) {
+        throw new Error('Accessing from Xray wrapper is not supported.');
+      }
       const sheets = this[INTERNAL_DOC_SHEETS] ?? [];
       if (!options.firefoxCollection) {
         return sheets;
@@ -218,6 +250,9 @@ function createAdoptedDescriptor<T extends Document | ShadowRoot>(
       return createFirefoxStyleSheetCollection(sheets);
     },
     set(this: T & { [INTERNAL_DOC_SHEETS]?: CSSStyleSheet[] }, value: CSSStyleSheet[]) {
+      if (this instanceof window.ShadowRoot && options.shadowAccessBlocked) {
+        throw new Error('Accessing from Xray wrapper is not supported.');
+      }
       this[INTERNAL_DOC_SHEETS] = value;
     }
   };

--- a/tests/e2e/phase4/shadow-dom.test.ts
+++ b/tests/e2e/phase4/shadow-dom.test.ts
@@ -63,6 +63,31 @@ describe('phase4/shadow-dom adoptedStyleSheets', () => {
     );
   });
 
+  it('handles Firefox-style adoptedStyleSheets collections without Array methods', async () => {
+    await withDomEnvironment(
+      '<!DOCTYPE html><html><body></body></html>',
+      { globals: DOM_GLOBALS },
+      async ({ document, window }) => {
+        const restoreFetch = stubClipperFetch(window);
+        const restore = enableConstructableStyles(window, { firefoxCollection: true });
+        try {
+          await clipperStyleSheetManager.initialize();
+
+          const host = document.createElement('div');
+          document.body.append(host);
+          const shadow = host.attachShadow({ mode: 'open' });
+
+          expect(() => clipperStyleSheetManager.applyTo(shadow)).not.toThrow();
+          expect(Array.from(shadow.adoptedStyleSheets)).toHaveLength(2);
+          expect(shadow.querySelectorAll('style')).toHaveLength(0);
+        } finally {
+          restore();
+          restoreFetch();
+        }
+      }
+    );
+  });
+
   it('falls back to inline style tags when constructable styles are unavailable', async () => {
     await withDomEnvironment(
       '<!DOCTYPE html><html><body></body></html>',
@@ -119,7 +144,10 @@ function stubClipperFetch(window: WindowShim): () => void {
   };
 }
 
-function enableConstructableStyles(window: WindowShim): () => void {
+function enableConstructableStyles(
+  window: WindowShim,
+  options: { firefoxCollection?: boolean } = {}
+): () => void {
   const globals = globalThis as typeof globalThis & {
     Document?: typeof window.Document;
     CSSStyleSheet?: typeof window.CSSStyleSheet;
@@ -141,8 +169,12 @@ function enableConstructableStyles(window: WindowShim): () => void {
     'adoptedStyleSheets'
   );
 
-  Object.defineProperty(docProto, 'adoptedStyleSheets', createAdoptedDescriptor<Document>());
-  Object.defineProperty(shadowProto, 'adoptedStyleSheets', createAdoptedDescriptor<ShadowRoot>());
+  Object.defineProperty(docProto, 'adoptedStyleSheets', createAdoptedDescriptor<Document>(options));
+  Object.defineProperty(
+    shadowProto,
+    'adoptedStyleSheets',
+    createAdoptedDescriptor<ShadowRoot>(options)
+  );
 
   class FakeConstructableStyleSheet {
     private cssText = '';
@@ -173,14 +205,32 @@ function enableConstructableStyles(window: WindowShim): () => void {
   };
 }
 
-function createAdoptedDescriptor<T extends Document | ShadowRoot>(): PropertyDescriptor {
+function createAdoptedDescriptor<T extends Document | ShadowRoot>(
+  options: { firefoxCollection?: boolean } = {}
+): PropertyDescriptor {
   return {
     configurable: true,
     get(this: T & { [INTERNAL_DOC_SHEETS]?: CSSStyleSheet[] }) {
-      return this[INTERNAL_DOC_SHEETS] ?? [];
+      const sheets = this[INTERNAL_DOC_SHEETS] ?? [];
+      if (!options.firefoxCollection) {
+        return sheets;
+      }
+      return createFirefoxStyleSheetCollection(sheets);
     },
     set(this: T & { [INTERNAL_DOC_SHEETS]?: CSSStyleSheet[] }, value: CSSStyleSheet[]) {
       this[INTERNAL_DOC_SHEETS] = value;
     }
   };
+}
+
+function createFirefoxStyleSheetCollection(sheets: CSSStyleSheet[]): CSSStyleSheet[] {
+  const collection = {
+    length: sheets.length,
+    item: (index: number) => sheets[index] ?? null,
+    [Symbol.iterator]: () => sheets[Symbol.iterator]()
+  } as CSSStyleSheet[] & { item(index: number): CSSStyleSheet | null };
+  sheets.forEach((sheet, index) => {
+    collection[index] = sheet;
+  });
+  return collection;
 }

--- a/tests/firefox/firefox.test.ts
+++ b/tests/firefox/firefox.test.ts
@@ -115,6 +115,28 @@ describe('Firefox 平台服务', () => {
     expect(storageSet).toHaveBeenCalledWith({ [testKey]: testValue });
   });
 
+  it('应该在 Firefox 暴露 chrome runtime 命名空间时仍使用 Firefox 默认平台服务', async () => {
+    Object.defineProperty(globalThis, 'chrome', {
+      configurable: true,
+      writable: true,
+      value: { runtime: {} }
+    });
+    const { getPlatformServices, resetPlatformServices } = await import('../../src/platform');
+
+    resetPlatformServices();
+    const services = getPlatformServices();
+    await services.storage.sync.set('key', 'value');
+
+    if (!firefoxHandle) {
+      throw new Error('Firefox mock 尚未初始化');
+    }
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(vi.mocked(firefoxHandle.browser.storage.sync.set)).toHaveBeenCalledWith({
+      key: 'value'
+    });
+    resetPlatformServices();
+  });
+
   it('应该使用 Firefox messaging API', async () => {
     const { firefoxMessagingService } = await import('../../src/platform/firefox/messaging');
 

--- a/tests/unit/background/runtimeMessages.test.ts
+++ b/tests/unit/background/runtimeMessages.test.ts
@@ -405,6 +405,32 @@ describe('runtime message listener', () => {
     expect(trackUsageEventMock).toHaveBeenCalledWith('support_like_clicked', { variant: 'first' });
   });
 
+  it('returns an explicit ack for analytics runtime messages', async () => {
+    const { registerRuntimeMessageListener } =
+      await import('../../../src/background/listeners/runtimeMessages');
+    registerRuntimeMessageListener(createDependencies());
+
+    await expect(
+      listener?.(
+        {
+          type: 'ANALYTICS_EVENT',
+          event: 'video_exported',
+          params: {
+            platform: 'youtube',
+            destination: 'downloads',
+            duration_bucket: '3s_to_9s'
+          }
+        },
+        { tabId: 12 }
+      )
+    ).resolves.toEqual({ success: true });
+    expect(trackUsageEventMock).toHaveBeenCalledWith('video_exported', {
+      platform: 'youtube',
+      destination: 'downloads',
+      duration_bucket: '3s_to_9s'
+    });
+  });
+
   it('maps onboarding and export success runtime events to activation milestones', async () => {
     const { registerRuntimeMessageListener } =
       await import('../../../src/background/listeners/runtimeMessages');

--- a/tests/unit/content/bootstrap.test.ts
+++ b/tests/unit/content/bootstrap.test.ts
@@ -26,6 +26,7 @@ type GlobalErrorBoundaryArgs = {
   metadata: {
     extensionContext: string;
   };
+  shouldReport: () => boolean;
   target: Window & typeof globalThis;
 };
 
@@ -201,6 +202,7 @@ describe('content/bootstrap', () => {
     expect(boundaryRegistration?.domain).toBe('content');
     expect(boundaryRegistration?.metadata?.extensionContext).toBe('content');
     expect(boundaryRegistration?.target).toBe(window);
+    expect(boundaryRegistration?.shouldReport).toBeTypeOf('function');
     expect(configureAnalyticsConfigManagerMock).not.toHaveBeenCalled();
     expect(initializeErrorAnalyticsMock).not.toHaveBeenCalled();
     expect(scopedRegistryMock.register).toHaveBeenCalledWith(

--- a/tests/unit/content/contentErrorSourcePolicy.test.ts
+++ b/tests/unit/content/contentErrorSourcePolicy.test.ts
@@ -1,0 +1,147 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest';
+import { shouldReportContentGlobalError } from '@content/contentErrorSourcePolicy';
+import type { GlobalErrorBoundaryReport } from '../../../src/shared/errors/globalErrorBoundary';
+
+function createErrorEvent(filename: string): ErrorEvent {
+  return new ErrorEvent('error', {
+    message: 'boom',
+    error: new Error('boom'),
+    filename
+  });
+}
+
+function createErrorEventWithReason(args: {
+  filename: string;
+  message: string;
+  reason: GlobalErrorBoundaryReport['reason'];
+}): ErrorEvent {
+  return new ErrorEvent('error', {
+    message: args.message,
+    error: args.reason,
+    filename: args.filename
+  });
+}
+
+function createReport(
+  overrides: Omit<GlobalErrorBoundaryReport, 'metadata'>
+): GlobalErrorBoundaryReport {
+  return {
+    ...overrides,
+    metadata: { eventType: overrides.eventType }
+  };
+}
+
+describe('shouldReportContentGlobalError', () => {
+  it('ignores page-origin script errors from content global listeners', () => {
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'error',
+          event: createErrorEvent('https://www.youtube.com/s/player/base.js'),
+          reason: new Error('page boom')
+        })
+      })
+    ).toBe(false);
+  });
+
+  it('reports extension-origin script errors', () => {
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'error',
+          event: createErrorEvent('moz-extension://extension-id/chunks/content.js'),
+          reason: new Error('extension boom')
+        })
+      })
+    ).toBe(true);
+  });
+
+  it('ignores browser ResizeObserver loop notifications even when Firefox attributes them to an extension chunk', () => {
+    const message = 'ResizeObserver loop completed with undelivered notifications.';
+
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'error',
+          event: createErrorEventWithReason({
+            filename: 'moz-extension://extension-id/chunks/content.js',
+            message,
+            reason: message
+          }),
+          reason: message
+        })
+      })
+    ).toBe(false);
+  });
+
+  it('keeps no-filename errors reportable to avoid hiding extension failures', () => {
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'error',
+          event: createErrorEvent(''),
+          reason: new Error('anonymous boom')
+        })
+      })
+    ).toBe(true);
+  });
+
+  it('uses rejection stacks when Firefox omits an event filename', () => {
+    const pageError = new Error('page rejection');
+    pageError.stack = 'Error: page rejection\n    at https://developer.mozilla.org/page.js:1:1';
+    const extensionError = new Error('extension rejection');
+    extensionError.stack =
+      'Error: extension rejection\n    at moz-extension://extension-id/chunks/content.js:1:1';
+
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'unhandledrejection',
+          event: new Event('unhandledrejection'),
+          reason: pageError
+        })
+      })
+    ).toBe(false);
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'unhandledrejection',
+          event: new Event('unhandledrejection'),
+          reason: extensionError
+        })
+      })
+    ).toBe(true);
+  });
+
+  it('uses structural rejection stacks when Firefox exposes page errors across realms', () => {
+    const pageReason = {
+      message: 'page rejection',
+      stack: 'Error: page rejection\n    at https://www.youtube.com/s/player/base.js:1:1'
+    };
+    const extensionReason = {
+      message: 'extension rejection',
+      stack: 'Error: extension rejection\n    at moz-extension://extension-id/chunks/content.js:1:1'
+    };
+
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'unhandledrejection',
+          event: new Event('unhandledrejection'),
+          reason: pageReason
+        })
+      })
+    ).toBe(false);
+    expect(
+      shouldReportContentGlobalError({
+        ...createReport({
+          eventType: 'unhandledrejection',
+          event: new Event('unhandledrejection'),
+          reason: extensionReason
+        })
+      })
+    ).toBe(true);
+  });
+});

--- a/tests/unit/content/dependencyFactories.test.ts
+++ b/tests/unit/content/dependencyFactories.test.ts
@@ -1,12 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getPlatformServicesMock = vi.hoisted(() => vi.fn());
+const isFirefoxMock = vi.hoisted(() => vi.fn(() => false));
+const visibleTabScreenshotMocks = vi.hoisted(() => {
+  const chromeCapture = vi.fn();
+  const firefoxCapture = vi.fn();
+  return {
+    chromeCapture,
+    firefoxCapture,
+    createChromeCapture: vi.fn(() => chromeCapture),
+    createFirefoxCapture: vi.fn(() => firefoxCapture)
+  };
+});
 const createAIChatExtractorMock = vi.hoisted(() =>
   vi.fn(() => ({
     id: 'ai.chat',
     priority: 200,
-    canHandle: vi.fn(async () => true),
-    extract: vi.fn(async () => ({
+    canHandle: vi.fn().mockResolvedValue(true),
+    extract: vi.fn().mockResolvedValue({
       type: 'ai_chat',
       title: 'mock',
       markdown: '',
@@ -17,7 +28,7 @@ const createAIChatExtractorMock = vi.hoisted(() =>
         messageCount: 0,
         clippedAtISO: '2024-01-01T00:00:00.000Z'
       }
-    }))
+    })
   }))
 );
 vi.mock('../../../src/platform', async () => {
@@ -31,17 +42,65 @@ vi.mock('../../../src/platform', async () => {
 vi.mock('@content/extractors/aiChatExtractor', () => ({
   createAIChatExtractor: createAIChatExtractorMock
 }));
+vi.mock('@content/video/videoVisibleTabScreenshot', async () => {
+  const actual = await vi.importActual<typeof import('@content/video/videoVisibleTabScreenshot')>(
+    '@content/video/videoVisibleTabScreenshot'
+  );
+  return {
+    ...actual,
+    createVisibleTabVideoFrameScreenshotCapture: visibleTabScreenshotMocks.createChromeCapture,
+    createVisibleTabVideoFrameScreenshotDataUrlCapture:
+      visibleTabScreenshotMocks.createFirefoxCapture
+  };
+});
+vi.mock('@shared/utils/browserDetection', async () => {
+  const actual = await vi.importActual<typeof import('@shared/utils/browserDetection')>(
+    '@shared/utils/browserDetection'
+  );
+  return {
+    ...actual,
+    isFirefox: isFirefoxMock
+  };
+});
 
 import { createDefaultExtractorRegistry } from '@content/extractors/registry';
 import { createReaderSessionDependencies } from '@content/reader/sessionDependencies';
 import { createVideoPromptDependencies } from '@content/video/videoPromptDependencies';
-import { createVideoSessionDependencies } from '@content/video/sessionDependencies';
+import {
+  createVideoSessionDependencies,
+  type VideoSessionPlatformDependencies
+} from '@content/video/sessionDependencies';
+import { createMemoryStorageService } from '@platform/preview/memoryStorage';
 import { repositoryContainer } from '@shared/di/serviceRegistry';
 import { DI_TOKENS } from '@shared/di/tokens';
+
+function createOptionsRepository(): VideoSessionPlatformDependencies['optionsRepository'] {
+  return {
+    get: vi.fn(() =>
+      Promise.reject(new Error('Unexpected options get in dependency factory test'))
+    ),
+    set: vi.fn(() => Promise.resolve()),
+    onChange: vi.fn(() => () => undefined)
+  };
+}
+
+function createVideoPlatform(
+  overrides: Partial<VideoSessionPlatformDependencies> = {}
+): VideoSessionPlatformDependencies {
+  return {
+    optionsRepository: createOptionsRepository(),
+    storage: createMemoryStorageService(),
+    ...overrides
+  };
+}
+
+type TestMessageSend = NonNullable<VideoSessionPlatformDependencies['messaging']>['send'];
+type TestMessagePayload = Parameters<TestMessageSend>[0];
 
 describe('content dependency factories', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isFirefoxMock.mockReturnValue(false);
     repositoryContainer.reset();
     repositoryContainer.registerSingleton(DI_TOKENS.IReaderRepository, () => ({
       loadHighlights: vi.fn(),
@@ -83,52 +142,92 @@ describe('content dependency factories', () => {
   });
 
   it('does not call getPlatformServices inside video session factory', () => {
-    const platform = {
-      optionsRepository: {
-        get: vi.fn().mockResolvedValue({}),
-        set: vi.fn(),
-        onChange: vi.fn(() => () => undefined)
-      },
-      storage: { sync: {}, local: {}, session: {} }
-    };
-    const dependencies = createVideoSessionDependencies(platform as never);
+    const platform = createVideoPlatform();
+    const dependencies = createVideoSessionDependencies(platform);
 
     expect(typeof dependencies.optionsRepository.get).toBe('function');
     expect(typeof dependencies.optionsRepository.onChange).toBe('function');
     expect(getPlatformServicesMock).not.toHaveBeenCalled();
   });
 
-  it('wires video screenshot cache through runtime messaging when available', async () => {
-    const send = vi.fn(() =>
-      Promise.resolve({
-        success: true,
-        operation: 'save',
-        result: {
-          status: 'skipped',
-          reason: 'invalid-metadata',
-          field: 'pageKey'
-        }
-      })
-    );
-    const platform = {
-      optionsRepository: {
-        get: vi.fn().mockResolvedValue({}),
-        set: vi.fn(),
-        onChange: vi.fn(() => () => undefined)
-      },
-      storage: {
-        sync: {},
-        local: {
-          get: vi.fn(),
-          set: vi.fn(),
-          setMany: vi.fn(),
-          remove: vi.fn()
-        },
-        session: {}
-      },
-      messaging: { send }
+  it('leaves Chrome video frame capture on the default blob path', () => {
+    isFirefoxMock.mockReturnValue(false);
+    const platform = createVideoPlatform();
+
+    const dependencies = createVideoSessionDependencies(platform);
+
+    expect(dependencies.captureVideoFrameScreenshot).toBeUndefined();
+  });
+
+  it('injects a Firefox-safe video frame capture provider only for Firefox', () => {
+    isFirefoxMock.mockReturnValue(true);
+    const platform = createVideoPlatform();
+
+    const dependencies = createVideoSessionDependencies(platform);
+
+    expect(dependencies.captureVideoFrameScreenshot).toBeTypeOf('function');
+  });
+
+  it('wires Chrome visible-tab screenshots through the existing Blob provider', () => {
+    isFirefoxMock.mockReturnValue(false);
+    const messaging = {
+      send: vi.fn()
     };
-    const dependencies = createVideoSessionDependencies(platform as never);
+    const platform = createVideoPlatform({
+      messaging
+    });
+
+    const dependencies = createVideoSessionDependencies(platform);
+
+    expect(visibleTabScreenshotMocks.createChromeCapture).toHaveBeenCalledWith({ messaging });
+    expect(visibleTabScreenshotMocks.createFirefoxCapture).not.toHaveBeenCalled();
+    expect(dependencies.captureVisibleVideoFrameScreenshot).toBe(
+      visibleTabScreenshotMocks.chromeCapture
+    );
+  });
+
+  it('wires Firefox visible-tab screenshots through the data URL provider', () => {
+    isFirefoxMock.mockReturnValue(true);
+    const messaging = {
+      send: vi.fn()
+    };
+    const platform = createVideoPlatform({
+      messaging
+    });
+
+    const dependencies = createVideoSessionDependencies(platform);
+
+    expect(visibleTabScreenshotMocks.createChromeCapture).not.toHaveBeenCalled();
+    expect(visibleTabScreenshotMocks.createFirefoxCapture).toHaveBeenCalledWith({ messaging });
+    expect(dependencies.captureVisibleVideoFrameScreenshot).toBe(
+      visibleTabScreenshotMocks.firefoxCapture
+    );
+  });
+
+  it('wires video screenshot cache through runtime messaging when available', async () => {
+    const sentMessages: TestMessagePayload[] = [];
+    const cacheResponse = {
+      success: true,
+      operation: 'save',
+      result: {
+        status: 'skipped',
+        reason: 'invalid-metadata',
+        field: 'pageKey'
+      }
+    };
+    const send: TestMessageSend = <TResult = never>(message: TestMessagePayload) => {
+      sentMessages.push(message);
+      return Promise.resolve(cacheResponse as TResult);
+    };
+    const storage = createMemoryStorageService();
+    const localSet = vi.spyOn(storage.local, 'set');
+    const localSetMany = vi.spyOn(storage.local, 'setMany');
+    const localRemove = vi.spyOn(storage.local, 'remove');
+    const platform = createVideoPlatform({
+      storage,
+      messaging: { send }
+    });
+    const dependencies = createVideoSessionDependencies(platform);
 
     expect(dependencies.screenshotCacheRepository).toBeDefined();
     const blob = new Blob(['frame'], { type: 'image/jpeg' });
@@ -148,15 +247,15 @@ describe('content dependency factories', () => {
       }
     });
 
-    expect(send).toHaveBeenCalledWith(
+    expect(sentMessages).toContainEqual(
       expect.objectContaining({
         type: 'AIIOB_VIDEO_SCREENSHOT_CACHE',
         operation: 'save'
       })
     );
-    expect(platform.storage.local.set).not.toHaveBeenCalled();
-    expect(platform.storage.local.setMany).not.toHaveBeenCalled();
-    expect(platform.storage.local.remove).not.toHaveBeenCalled();
+    expect(localSet).not.toHaveBeenCalled();
+    expect(localSetMany).not.toHaveBeenCalled();
+    expect(localRemove).not.toHaveBeenCalled();
   });
 
   it('does not call getPlatformServices inside video prompt factory', () => {

--- a/tests/unit/content/reader/ReaderDialogPanel.test.ts
+++ b/tests/unit/content/reader/ReaderDialogPanel.test.ts
@@ -95,17 +95,20 @@ describe('ReaderDialogPanel', () => {
     });
     panel.mount(document.body);
 
-    panel.setHighlights([
-      {
-        id: 'h-1',
-        index: 1,
-        excerpt: 'Selected text',
-        fullText: 'Selected text',
-        comment: '',
-        commentPreview: '',
-        timestamp: Date.now()
-      }
-    ]);
+    panel.setHighlights(
+      [
+        {
+          id: 'h-1',
+          index: 1,
+          excerpt: 'Selected text',
+          fullText: 'Selected text',
+          comment: '',
+          commentPreview: '',
+          timestamp: Date.now()
+        }
+      ],
+      { focusHighlightId: 'h-1' }
+    );
 
     const noteInput = panel.element.shadowRoot?.querySelector('[data-highlight-input="h-1"]');
     expect(panel.element.shadowRoot?.activeElement).toBe(noteInput);
@@ -113,6 +116,50 @@ describe('ReaderDialogPanel', () => {
     panel.update({ hint: 'Updated hint after capture' });
     expect(panel.element.shadowRoot?.activeElement).toBe(
       panel.element.shadowRoot?.querySelector('[data-highlight-input="h-1"]')
+    );
+
+    panel.destroy();
+  });
+
+  it('focuses the newly inserted highlight note input when document order places it between existing notes', () => {
+    const panel = new ReaderDialogPanel({
+      texts: createReaderPanelTexts(),
+      callbacks: createReaderPanelCallbacks()
+    });
+    panel.mount(document.body);
+    const first = createHighlight({ id: 'h-1', index: 1 });
+    const last = createHighlight({ id: 'h-3', index: 2 });
+    panel.setHighlights([first, last]);
+
+    panel.setHighlights(
+      [
+        createHighlight({ id: 'h-1', index: 1 }),
+        createHighlight({ id: 'h-2', index: 2 }),
+        createHighlight({ id: 'h-3', index: 3 })
+      ],
+      { focusHighlightId: 'h-2' }
+    );
+
+    expect(panel.element.shadowRoot?.activeElement).toBe(
+      panel.element.shadowRoot?.querySelector('[data-highlight-input="h-2"]')
+    );
+
+    panel.destroy();
+  });
+
+  it('does not focus a note input when highlights hydrate without an explicit focus target', () => {
+    const panel = new ReaderDialogPanel({
+      texts: createReaderPanelTexts(),
+      callbacks: createReaderPanelCallbacks()
+    });
+    panel.mount(document.body);
+    const restoredFirst = createHighlight({ id: 'saved-1', index: 1 });
+    const restoredSecond = createHighlight({ id: 'saved-2', index: 2 });
+
+    panel.setHighlights([restoredFirst, restoredSecond]);
+
+    expect(panel.element.shadowRoot?.activeElement).not.toBe(
+      panel.element.shadowRoot?.querySelector('[data-highlight-input="saved-2"]')
     );
 
     panel.destroy();
@@ -154,17 +201,20 @@ describe('ReaderDialogPanel', () => {
     });
     panel.mount(document.body);
 
-    panel.setHighlights([
-      {
-        id: 'h-1',
-        index: 1,
-        excerpt: 'Selected text',
-        fullText: 'Selected text',
-        comment: '',
-        commentPreview: '',
-        timestamp: Date.now()
-      }
-    ]);
+    panel.setHighlights(
+      [
+        {
+          id: 'h-1',
+          index: 1,
+          excerpt: 'Selected text',
+          fullText: 'Selected text',
+          comment: '',
+          commentPreview: '',
+          timestamp: Date.now()
+        }
+      ],
+      { focusHighlightId: 'h-1' }
+    );
 
     expect(panel.isEditing()).toBe(true);
     panel.element.shadowRoot?.querySelector<HTMLButtonElement>('[data-role="export-btn"]')?.focus();
@@ -194,7 +244,9 @@ describe('ReaderDialogPanel', () => {
     secondInput.value = 'second draft';
     secondInput.dispatchEvent(new Event('input', { bubbles: true }));
 
-    panel.setHighlights([first, second, createHighlight({ id: 'h-3', index: 3 })]);
+    panel.setHighlights([first, second, createHighlight({ id: 'h-3', index: 3 })], {
+      focusHighlightId: 'h-3'
+    });
 
     expect(
       panel.element.shadowRoot?.querySelector<HTMLInputElement>('[data-highlight-input="h-2"]')
@@ -344,7 +396,7 @@ describe('ReaderDialogPanel', () => {
     panel.destroy();
   });
 
-  it('keeps restored collapse when the initial highlight list hydrates', async () => {
+  it('keeps restored collapse on hydrate and expands when a new focused highlight is added', async () => {
     await testPlatformHarness.storage.local.set('aiob.sessionPanel.collapsed', true);
     const panel = new ReaderDialogPanel({
       texts: createReaderPanelTexts(),
@@ -364,7 +416,7 @@ describe('ReaderDialogPanel', () => {
     ).toBe(true);
     expect(await testPlatformHarness.storage.local.get('aiob.sessionPanel.collapsed')).toBe(true);
 
-    panel.setHighlights([first, second]);
+    panel.setHighlights([first, second], { focusHighlightId: second.id });
 
     expect(
       panel.element.shadowRoot

--- a/tests/unit/content/reader/ReaderSession.test.ts
+++ b/tests/unit/content/reader/ReaderSession.test.ts
@@ -12,6 +12,7 @@ import type {
 } from '@content/reader/application/readerPanelModel';
 import type {
   ReaderPanelEditingSnapshot,
+  ReaderPanelRenderOptions,
   ReaderSessionView,
   ReaderSessionViewOptions
 } from '@content/reader/application/readerSessionView';
@@ -61,7 +62,9 @@ type TestView = ReaderSessionView & {
   updateHint: Mock<(...args: [message: string]) => void>;
   updateTexts: Mock<(...args: [texts: ReaderPanelTexts]) => void>;
   updateDestination: Mock<(...args: [destination: unknown]) => void>;
-  setHighlights: Mock<(...args: [highlights: ReaderPanelHighlight[]]) => void>;
+  setHighlights: Mock<
+    (...args: [highlights: ReaderPanelHighlight[], options?: ReaderPanelRenderOptions]) => void
+  >;
   snapshotCommentDrafts: Mock<(...args: []) => SessionCommentDraftSnapshot>;
   hydrateCommentDrafts: Mock<(...args: [drafts: SessionCommentDraftSnapshot]) => void>;
   clearCommentDraft: Mock<(...args: [id: string]) => void>;
@@ -584,7 +587,7 @@ describe('ReaderSession', () => {
     expect(context.environment.start).toHaveBeenCalledTimes(1);
     expect(context.getCallbacks()).toBeDefined();
     expect(context.view.updateCount).toHaveBeenLastCalledWith(0);
-    expect(context.view.setHighlights).toHaveBeenLastCalledWith([]);
+    expect(context.view.setHighlights).toHaveBeenLastCalledWith([], {});
     expect(getSessionHarness(context.session).__testHighlights).toEqual([]);
   });
 
@@ -619,6 +622,11 @@ describe('ReaderSession', () => {
       destination: { kind: 'vault', vaultId: 'research' }
     });
 
+    const [createdHighlight] = getSessionHarness(context.session).__testHighlights;
+    expect(createdHighlight).toBeDefined();
+    expect(context.view.setHighlights).toHaveBeenLastCalledWith(expect.any(Array), {
+      focusHighlightId: createdHighlight?.id
+    });
     expect(context.view.updateDestination).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'research',
@@ -673,6 +681,7 @@ describe('ReaderSession', () => {
     expect(context.view.currentDrafts).toEqual({
       'saved-1': 'unsaved note'
     });
+    expect(context.view.setHighlights).toHaveBeenLastCalledWith(expect.any(Array), {});
     expect(context.view.updateDestination).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'research',

--- a/tests/unit/content/reader/panelCoordinator.test.ts
+++ b/tests/unit/content/reader/panelCoordinator.test.ts
@@ -9,6 +9,7 @@ import type {
 } from '@content/reader/application/readerPanelModel';
 import type {
   ReaderPanelEditingSnapshot,
+  ReaderPanelRenderOptions,
   ReaderSessionView
 } from '@content/reader/application/readerSessionView';
 import type { ReaderSessionViewFactory } from '@content/reader/application/readerSessionView';
@@ -22,6 +23,7 @@ class FakeReaderView implements ReaderSessionView {
   lastHint = '';
   lastTexts: ReaderPanelTexts | null = null;
   lastHighlights: ReaderPanelHighlight[] = [];
+  lastRenderOptions: ReaderPanelRenderOptions = {};
   currentDrafts: Record<string, string> = {};
   editingSnapshot: ReaderPanelEditingSnapshot = {
     editingHighlightId: null,
@@ -42,8 +44,9 @@ class FakeReaderView implements ReaderSessionView {
     this.lastTexts = texts;
   }
 
-  setHighlights(highlights: ReaderPanelHighlight[]): void {
+  setHighlights(highlights: ReaderPanelHighlight[], options: ReaderPanelRenderOptions = {}): void {
     this.lastHighlights = highlights;
+    this.lastRenderOptions = options;
   }
 
   snapshotCommentDrafts(): Record<string, string> {
@@ -182,6 +185,21 @@ describe('ReaderPanelCoordinator', () => {
     expect(view.lastHint).toBe(DEFAULT_SESSION_MESSAGES.panel.hint);
     coordinator.stopEditing();
     expect(view.editing).toBe(false);
+  });
+
+  it('forwards the requested highlight focus target through presenter rendering', () => {
+    const coordinator = new ReaderPanelCoordinator({
+      viewFactory,
+      callbacks,
+      reconstructText: (highlight) => highlight.selectedText
+    });
+
+    coordinator.mount(DEFAULT_SESSION_MESSAGES);
+    coordinator.updateHighlights([createHighlight('a', 'note', 'Content')], {
+      focusHighlightId: 'a'
+    });
+
+    expect(view.lastRenderOptions).toEqual({ focusHighlightId: 'a' });
   });
 
   it('forwards comment draft snapshot and hydrate operations to the view', () => {

--- a/tests/unit/content/video/videoFrameScreenshot.test.ts
+++ b/tests/unit/content/video/videoFrameScreenshot.test.ts
@@ -9,7 +9,8 @@ import {
 import { VIDEO_SCREENSHOT_CACHE_MAX_CONTENT_BYTES } from '@content/video/videoScreenshotCacheTypes';
 import {
   captureVideoFrameScreenshot,
-  captureVideoFrameScreenshotAsync
+  captureVideoFrameScreenshotAsync,
+  captureVideoFrameScreenshotDataUrl
 } from '@content/video/videoFrameScreenshot';
 import type { VideoTimestampCapture } from '@content/video/types';
 
@@ -350,6 +351,34 @@ describe('captureVideoFrameScreenshot', () => {
     await expect(captureVideoFrameScreenshotAsync(harness.video, 42, 1)).resolves.toBeNull();
     expect(harness.blobAttempts).toEqual([]);
     expect(harness.dataUrlAttempts).toEqual([]);
+
+    harness.restore();
+  });
+
+  it('captures a Firefox-safe dataUrl screenshot without blob content', () => {
+    const harness = createCaptureCanvasHarness({
+      toDataURL: () => 'data:image/jpeg;base64,ZmlyZWZveC1mcmFtZQ=='
+    });
+
+    const screenshot = captureVideoFrameScreenshotDataUrl(harness.video, 42, 1);
+
+    expect(harness.canvases[0]?.drawImage).toHaveBeenCalledWith(harness.video, 0, 0, 640, 360);
+    expect(harness.blobAttempts).toEqual([]);
+    expect(harness.dataUrlAttempts).toEqual([
+      {
+        width: 640,
+        height: 360,
+        quality: 0.78,
+        type: 'image/jpeg',
+        callIndex: 0
+      }
+    ]);
+    expect(screenshot?.id).toMatch(/^screenshot-/u);
+    expect(screenshot?.fileName).toMatch(/^file-\d{17}\.jpg$/u);
+    expect(screenshot?.mimeType).toBe('image/jpeg');
+    expect(screenshot?.capturedAt).toBe(1);
+    expect(screenshot?.dataUrl).toBe('data:image/jpeg;base64,ZmlyZWZveC1mcmFtZQ==');
+    expect(screenshot).not.toHaveProperty('content');
 
     harness.restore();
   });

--- a/tests/unit/content/video/videoScreenshotAttachmentSerialization.test.ts
+++ b/tests/unit/content/video/videoScreenshotAttachmentSerialization.test.ts
@@ -1,0 +1,100 @@
+/* @vitest-environment node */
+
+import { describe, expect, it } from 'vitest';
+import { serializeVideoScreenshotAttachment } from '@content/video/videoScreenshotAttachmentSerialization';
+import type { VideoCaptureScreenshot } from '@content/video/types';
+
+function createBlobScreenshot(
+  overrides: Partial<VideoCaptureScreenshot> = {}
+): VideoCaptureScreenshot {
+  const blob = new Blob(['frame'], { type: 'image/jpeg' });
+  return {
+    id: 'shot-blob',
+    fileName: 'shot-blob.jpg',
+    mimeType: 'image/jpeg',
+    capturedAt: 2_000_000_000_000,
+    content: {
+      kind: 'blob',
+      blob,
+      byteLength: blob.size
+    },
+    ...overrides
+  };
+}
+
+function createThrowingBlob(): Blob {
+  return {
+    size: 5,
+    type: 'image/jpeg',
+    arrayBuffer: () =>
+      Promise.reject(new Error('Permission denied to access property "constructor"'))
+  } as Blob;
+}
+
+describe('serializeVideoScreenshotAttachment', () => {
+  it('serializes readable blob screenshots as binary attachments', async () => {
+    const attachment = await serializeVideoScreenshotAttachment(createBlobScreenshot());
+
+    expect(attachment).toEqual({
+      id: 'shot-blob',
+      fileName: 'shot-blob.jpg',
+      mimeType: 'image/jpeg',
+      content: {
+        encoding: 'base64',
+        data: 'ZnJhbWU=',
+        byteLength: 5
+      }
+    });
+  });
+
+  it('falls back to dataUrl when Firefox blocks blob serialization', async () => {
+    const attachment = await serializeVideoScreenshotAttachment(
+      createBlobScreenshot({
+        id: 'shot-firefox',
+        fileName: 'shot-firefox.jpg',
+        dataUrl: 'data:image/jpeg;base64,ZmlyZWZveA==',
+        content: {
+          kind: 'blob',
+          blob: createThrowingBlob(),
+          byteLength: 7
+        }
+      })
+    );
+
+    expect(attachment).toEqual({
+      id: 'shot-firefox',
+      fileName: 'shot-firefox.jpg',
+      mimeType: 'image/jpeg',
+      dataUrl: 'data:image/jpeg;base64,ZmlyZWZveA=='
+    });
+  });
+
+  it('serializes dataUrl-only screenshots without requiring blob content', async () => {
+    const attachment = await serializeVideoScreenshotAttachment({
+      id: 'shot-data-url',
+      fileName: 'shot-data-url.jpg',
+      mimeType: 'image/jpeg',
+      capturedAt: 2_000_000_000_001,
+      dataUrl: 'data:image/jpeg;base64,ZGF0YQ=='
+    });
+
+    expect(attachment).toEqual({
+      id: 'shot-data-url',
+      fileName: 'shot-data-url.jpg',
+      mimeType: 'image/jpeg',
+      dataUrl: 'data:image/jpeg;base64,ZGF0YQ=='
+    });
+  });
+
+  it('rejects invalid dataUrl screenshots', async () => {
+    await expect(
+      serializeVideoScreenshotAttachment({
+        id: 'shot-invalid',
+        fileName: 'shot-invalid.jpg',
+        mimeType: 'image/jpeg',
+        capturedAt: 2_000_000_000_002,
+        dataUrl: 'data:image/png;base64,bm90LWpwZWc='
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/unit/content/video/videoScreenshotCacheBackgroundClient.test.ts
+++ b/tests/unit/content/video/videoScreenshotCacheBackgroundClient.test.ts
@@ -264,6 +264,15 @@ function createScreenshot(
   };
 }
 
+function createThrowingBlob(): Blob {
+  const blob = new Blob(['firefox'], { type: 'image/jpeg' });
+  Object.defineProperty(blob, 'arrayBuffer', {
+    configurable: true,
+    value: () => Promise.reject(new Error('Permission denied to access property "constructor"'))
+  });
+  return blob;
+}
+
 function requireSavedRef(
   result: Awaited<ReturnType<ReturnType<typeof createVideoScreenshotCacheRepository>['save']>>,
   label = 'expected screenshot cache save to succeed'
@@ -510,6 +519,80 @@ describe('background-owned video screenshot cache client', () => {
     expect(blobStore.peek(legacyRef.key)).not.toBeNull();
     expect(await legacyArea.get(legacyRef.key)).toBeUndefined();
     expectNoLegacyPayloadRows(legacyArea);
+  });
+
+  it('saves dataUrl-only screenshots through the background cache owner', async () => {
+    const legacyArea = new MemoryStorageArea();
+    const blobStore = new MemoryBlobStore();
+    const client = createVideoScreenshotCacheClientRepository({
+      messaging: createClientMessaging(
+        createBackgroundVideoScreenshotCacheHandler(
+          { local: legacyArea },
+          { now: () => BASE_TIME },
+          { blobStore }
+        )
+      )
+    });
+
+    const saved = await client.save({
+      pageKey: 'page-firefox',
+      captureId: 'capture-firefox',
+      screenshot: {
+        id: 'shot-firefox',
+        fileName: 'shot-firefox.jpg',
+        mimeType: 'image/jpeg',
+        capturedAt: BASE_TIME,
+        dataUrl: 'data:image/jpeg;base64,ZmlyZWZveA=='
+      }
+    });
+    const ref = requireSavedRef(saved);
+
+    expect(blobStore.peek(ref.key)).not.toBeNull();
+    const loaded = await client.load(ref);
+    expect(loaded).toMatchObject({
+      id: 'shot-firefox',
+      fileName: 'shot-firefox.jpg',
+      mimeType: 'image/jpeg',
+      capturedAt: BASE_TIME
+    });
+    await expect(loaded?.content?.blob.text()).resolves.toBe('firefox');
+  });
+
+  it('saves the dataUrl fallback when Firefox blocks blob serialization in the content client', async () => {
+    const legacyArea = new MemoryStorageArea();
+    const blobStore = new MemoryBlobStore();
+    const client = createVideoScreenshotCacheClientRepository({
+      messaging: createClientMessaging(
+        createBackgroundVideoScreenshotCacheHandler(
+          { local: legacyArea },
+          { now: () => BASE_TIME },
+          { blobStore }
+        )
+      )
+    });
+
+    const saved = await client.save({
+      pageKey: 'page-firefox',
+      captureId: 'capture-firefox',
+      screenshot: {
+        id: 'shot-firefox-fallback',
+        fileName: 'shot-firefox-fallback.jpg',
+        mimeType: 'image/jpeg',
+        capturedAt: BASE_TIME,
+        dataUrl: 'data:image/jpeg;base64,ZmlyZWZveA==',
+        content: {
+          kind: 'blob',
+          blob: createThrowingBlob(),
+          byteLength: 7
+        }
+      }
+    });
+    const ref = requireSavedRef(saved);
+
+    expect(blobStore.peek(ref.key)).not.toBeNull();
+    const loaded = await client.load(ref);
+    await expect(loaded?.content?.blob.text()).resolves.toBe('firefox');
+    expectNoLegacyScreenshotCacheWrites(legacyArea);
   });
 
   it('serializes removeMany and prune operations through the background owner and deletes blob entries', async () => {

--- a/tests/unit/content/video/videoSessionExporter.test.ts
+++ b/tests/unit/content/video/videoSessionExporter.test.ts
@@ -108,6 +108,43 @@ describe('VideoSessionExporter', () => {
     await expect(restoredBlob.text()).resolves.toBe('frame-live');
   });
 
+  it('exports Firefox-safe dataUrl screenshots through the existing attachment flow', async () => {
+    const repository = createRepository();
+    const exporter = new VideoSessionExporter(repository);
+
+    await exporter.export({
+      captures: [
+        createTimestampCapture('timestamp-firefox', 7, {
+          screenshotRequested: true,
+          screenshot: {
+            id: 'shot-firefox',
+            fileName: 'shot-firefox.jpg',
+            mimeType: 'image/jpeg',
+            capturedAt: 2_000_000_000_001,
+            dataUrl: 'data:image/jpeg;base64,ZmlyZWZveA=='
+          }
+        })
+      ],
+      videoTitle: 'Firefox Video',
+      canonicalUrl: 'https://video.example/watch?v=firefox',
+      videoUrl: 'https://video.example/watch?v=firefox',
+      platform: 'youtube',
+      messages: DEFAULT_SESSION_MESSAGES,
+      storageKey: 'video:firefox'
+    });
+
+    const exportedClip = readExportedClip(repository);
+    expect(exportedClip.content).toContain('![Screenshot](aiob-attachment:shot-firefox)');
+    expect(exportedClip.attachments).toEqual([
+      {
+        id: 'shot-firefox',
+        fileName: 'shot-firefox.jpg',
+        mimeType: 'image/jpeg',
+        dataUrl: 'data:image/jpeg;base64,ZmlyZWZveA=='
+      }
+    ]);
+  });
+
   it('filters missing requested screenshots while keeping live screenshot attachments exportable', async () => {
     const repository = createRepository();
     const exporter = new VideoSessionExporter(repository);

--- a/tests/unit/content/video/videoVisibleTabScreenshot.test.ts
+++ b/tests/unit/content/video/videoVisibleTabScreenshot.test.ts
@@ -1,7 +1,10 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createVisibleTabVideoFrameScreenshotCapture } from '@content/video/videoVisibleTabScreenshot';
+import {
+  createVisibleTabVideoFrameScreenshotCapture,
+  createVisibleTabVideoFrameScreenshotDataUrlCapture
+} from '@content/video/videoVisibleTabScreenshot';
 import { VIDEO_SCREENSHOT_CACHE_MAX_CONTENT_BYTES } from '@content/video/videoScreenshotCacheTypes';
 import {
   createCaptureVisibleTabScreenshotMessage,
@@ -59,8 +62,16 @@ function createCanvasHarness(
     canvas: HTMLCanvasElement;
     drawImage: ReturnType<typeof vi.fn>;
     toBlob: ReturnType<typeof vi.fn>;
+    toDataURL: ReturnType<typeof vi.fn>;
   }> = [];
   const blobAttempts: Array<{
+    width: number;
+    height: number;
+    quality: number | undefined;
+    type: string | undefined;
+    callIndex: number;
+  }> = [];
+  const dataUrlAttempts: Array<{
     width: number;
     height: number;
     quality: number | undefined;
@@ -86,6 +97,16 @@ function createCanvasHarness(
             : blobText(attempt);
         callback(blob);
       });
+      const toDataURL = vi.fn((type?: string, quality?: number) => {
+        dataUrlAttempts.push({
+          width: canvas.width,
+          height: canvas.height,
+          quality,
+          type,
+          callIndex: dataUrlAttempts.length
+        });
+        return 'data:image/jpeg;base64,Y3JvcHBlZA==';
+      });
       Object.defineProperty(canvas, 'getContext', {
         configurable: true,
         value: vi.fn(() => ({ drawImage }))
@@ -94,7 +115,11 @@ function createCanvasHarness(
         configurable: true,
         value: toBlob
       });
-      canvases.push({ canvas, drawImage, toBlob });
+      Object.defineProperty(canvas, 'toDataURL', {
+        configurable: true,
+        value: toDataURL
+      });
+      canvases.push({ canvas, drawImage, toBlob, toDataURL });
       return canvas;
     }
     return originalCreateElement(tagName);
@@ -102,6 +127,7 @@ function createCanvasHarness(
   return {
     canvases,
     blobAttempts,
+    dataUrlAttempts,
     restore() {
       createElementSpy.mockRestore();
     }
@@ -283,5 +309,51 @@ describe('createVisibleTabVideoFrameScreenshotCapture', () => {
 
     await expect(capture(document.createElement('video'), 42, 123)).resolves.toBeNull();
     expect(messaging.send).toHaveBeenCalledWith(createCaptureVisibleTabScreenshotMessage());
+  });
+
+  it('captures Firefox visible-tab screenshots as data URLs without creating Blob-backed content', async () => {
+    installImageMock({ width: 3840, height: 2160 });
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 1920
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 1080
+    });
+    const canvasHarness = createCanvasHarness();
+    const video = document.createElement('video');
+    vi.spyOn(video, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 1920, 1080));
+    const response: CaptureVisibleTabScreenshotResponse = {
+      success: true,
+      dataUrl: 'data:image/jpeg;base64,frame'
+    };
+    const messaging = {
+      send: vi.fn(() => Promise.resolve(response))
+    };
+    const capture = createVisibleTabVideoFrameScreenshotDataUrlCapture({
+      messaging: asType<Pick<MessagingService, 'send'>>(messaging)
+    });
+
+    const screenshot = await capture(video, 42, 123);
+
+    expect(messaging.send).toHaveBeenCalledWith(createCaptureVisibleTabScreenshotMessage());
+    expect(canvasHarness.dataUrlAttempts).toEqual([
+      {
+        width: 1280,
+        height: 720,
+        quality: 0.78,
+        type: 'image/jpeg',
+        callIndex: 0
+      }
+    ]);
+    expect(canvasHarness.blobAttempts).toEqual([]);
+    expect(screenshot).toMatchObject({
+      mimeType: 'image/jpeg',
+      capturedAt: 123,
+      dataUrl: 'data:image/jpeg;base64,Y3JvcHBlZA=='
+    });
+    expect(screenshot?.content).toBeUndefined();
+    canvasHarness.restore();
   });
 });

--- a/tests/unit/shared/browserDetection.test.ts
+++ b/tests/unit/shared/browserDetection.test.ts
@@ -44,6 +44,16 @@ describe('browserDetection', () => {
     expect(isChrome()).toBe(false);
   });
 
+  it('detects Firefox from user agent when Firefox also exposes the chrome runtime namespace', () => {
+    defineUserAgent('Mozilla/5.0 (Macintosh; rv:152.0) Gecko/20100101 Firefox/152.0');
+    installBrowserRuntime();
+    installChromeRuntime();
+
+    expect(detectBrowser()).toBe('firefox');
+    expect(isFirefox()).toBe(true);
+    expect(isChrome()).toBe(false);
+  });
+
   it('detects firefox mobile and adds html classes', () => {
     defineUserAgent('Mozilla/5.0 Firefox/124.0 Mobile');
     Reflect.deleteProperty(globalThis as typeof globalThis & { chrome?: unknown }, 'chrome');

--- a/tests/unit/shared/errors/globalErrorBoundary.test.ts
+++ b/tests/unit/shared/errors/globalErrorBoundary.test.ts
@@ -111,4 +111,27 @@ describe('globalErrorBoundary', () => {
 
     cleanup();
   });
+
+  it('skips events rejected by a caller-provided source policy', async () => {
+    const handle = vi.fn().mockResolvedValue(undefined);
+    const cleanup = registerGlobalErrorBoundary({
+      domain: 'content',
+      errorHandler: { handle },
+      target: window,
+      shouldReport: () => false
+    });
+
+    window.dispatchEvent(
+      new ErrorEvent('error', {
+        message: 'page boom',
+        error: new Error('page boom'),
+        filename: 'https://example.com/page.js'
+      })
+    );
+
+    await Promise.resolve();
+
+    expect(handle).not.toHaveBeenCalled();
+    cleanup();
+  });
 });


### PR DESCRIPTION
## Summary
- Harden Firefox content/runtime boundaries around shadow styles, content error attribution, analytics acknowledgements, and video screenshot attachment serialization.
- Keep video screenshot capture/export JSON-safe across Firefox visible-tab and cache fallback paths without weakening Chrome behavior.
- Integrate the reader highlight note-focus fix so newly added highlights focus their own note even after document-order sorting.

## Independent audit
- Subagent audit of `codex/reader-highlight-note-focus-2026-06-21` found no blocking or important issues before integration.
- Follow-up verification confirmed the integrated branch builds and tests as one PR range.

## Verification
- `git diff --check HEAD~5..HEAD`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npx vitest run --config vitest.unit.config.ts tests/unit/content/reader/ReaderDialogPanel.test.ts tests/unit/content/reader/ReaderSession.test.ts tests/unit/content/reader/panelCoordinator.test.ts tests/unit/content/bootstrap.test.ts tests/unit/content/contentErrorSourcePolicy.test.ts tests/unit/shared/errors/globalErrorBoundary.test.ts tests/unit/shared/browserDetection.test.ts tests/unit/content/dependencyFactories.test.ts tests/unit/content/video/videoFrameScreenshot.test.ts tests/unit/content/video/videoVisibleTabScreenshot.test.ts tests/unit/content/video/videoScreenshotCacheBackgroundClient.test.ts tests/unit/content/video/videoSessionExporter.test.ts tests/unit/background/runtimeMessages.test.ts`
- `npm run test:unit`
- `npm run verify:preflight`
- `npm run test:e2e:browser:reader-panel`
- `npm run test:e2e:browser:smoke`
- `node scripts/run-playwright.mjs test tests/e2e/videoPanelFlow.test.ts --project=chromium-desktop`
- `npm run package:firefox` (web-ext lint: 0 errors, 10 warnings)
- `npm run package`
