### PR TITLE
Fix context menu type ratchet before release packaging

### DIFF
--- a/src/background/listeners/contextMenuDispatch.ts
+++ b/src/background/listeners/contextMenuDispatch.ts
@@ -1,15 +1,11 @@
 import { notifyClipFailure } from '../services/notifications';
 import { contentErrors } from '../../shared/errors/contentErrors';
 
-function getObjectProperty(source: object, key: string): unknown {
-  return (source as Record<string, unknown>)[key];
-}
-
 export function resolveContentActionFailureMessage(response: object | undefined): string | null {
-  if (!response || getObjectProperty(response, 'success') !== false) {
+  if (!response || !('success' in response) || response.success !== false) {
     return null;
   }
-  const error = getObjectProperty(response, 'error');
+  const error = 'error' in response ? response.error : undefined;
   return typeof error === 'string' && error.trim().length > 0
     ? error
     : 'Content action reported failure';

--- a/src/background/listeners/contextMenuFrameSelectionBridge.ts
+++ b/src/background/listeners/contextMenuFrameSelectionBridge.ts
@@ -1,9 +1,5 @@
 import type { ContextMenuListenerDependencies } from './contextMenusTypes';
 
-function getObjectProperty(source: object, key: string): unknown {
-  return (source as Record<string, unknown>)[key];
-}
-
 export function registerFrameSelectionBridge({
   messaging,
   tabs
@@ -12,8 +8,7 @@ export function registerFrameSelectionBridge({
     if (!rawMessage || typeof rawMessage !== 'object') {
       return undefined;
     }
-    const messageType = getObjectProperty(rawMessage, 'type');
-    if (messageType !== 'AIIOB_FORWARD_VIDEO_SELECTION') {
+    if (!('type' in rawMessage) || rawMessage.type !== 'AIIOB_FORWARD_VIDEO_SELECTION') {
       return undefined;
     }
 
@@ -22,12 +17,12 @@ export function registerFrameSelectionBridge({
       return { success: false, error: 'NO_TAB' };
     }
 
-    const messagePayload = getObjectProperty(rawMessage, 'payload');
+    const messagePayload = 'payload' in rawMessage ? rawMessage.payload : undefined;
     const rawPayload =
       typeof messagePayload === 'object' && messagePayload !== null ? messagePayload : {};
-    const selectedHtml = getObjectProperty(rawPayload, 'selectedHtml');
-    const selectedText = getObjectProperty(rawPayload, 'selectedText');
-    const sourceUrl = getObjectProperty(rawPayload, 'sourceUrl');
+    const selectedHtml = 'selectedHtml' in rawPayload ? rawPayload.selectedHtml : undefined;
+    const selectedText = 'selectedText' in rawPayload ? rawPayload.selectedText : undefined;
+    const sourceUrl = 'sourceUrl' in rawPayload ? rawPayload.sourceUrl : undefined;
     const payload = {
       selectedHtml: String(selectedHtml ?? ''),
       selectedText: String(selectedText ?? ''),


### PR DESCRIPTION
## Summary
- Remove explicit Record<string, unknown> assertions from context menu dispatch helpers.
- Keep frame-selection forwarding behavior unchanged while bringing src type-debt counts back under the release quality gate.

## Test Plan
- npm run typecheck:app
- npm run lint:type-any:ratchet
- npx vitest run --config vitest.unit.config.ts tests/unit/background/contextMenus.test.ts tests/unit/content/contentMessageRouter.test.ts