### PR TITLE
Fix video frame forwarding dependency cycle

### DIFF
--- a/src/content/runtime/videoFrameSelectionForwarder.ts
+++ b/src/content/runtime/videoFrameSelectionForwarder.ts
@@ -1,8 +1,9 @@
 import type { MessagePayload, MessagingService } from '../../platform/interfaces/messaging';
-import type { ContentMessageHandlerContext } from './contentMessageHandlers';
 import { hasUsableSelection } from './selectionSnapshot';
 
-type ForwardContext = Pick<ContentMessageHandlerContext, 'document' | 'window' | 'messaging'> & {
+type ForwardContext = {
+  document: Document;
+  window: Window;
   messaging: Pick<MessagingService, 'send'>;
 };
 


### PR DESCRIPTION
## Summary
- Remove the type-only back edge from videoFrameSelectionForwarder to contentMessageHandlers.
- Keep the lazy iframe forwarding API structural and dependency-cruiser clean.

## Test Plan
- npm run typecheck:app
- npm run audit:deps:report
- npx vitest run --config vitest.unit.config.ts tests/unit/content/contentMessageRouter.test.ts
- npm run quality